### PR TITLE
refactor: remove redundant fd_ init and fix duplicate test node names

### DIFF
--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -38,8 +38,7 @@ Mpu6050Driver::Mpu6050Driver(
   const std::string & node_name,
   const rclcpp::NodeOptions & node_options,
   II2CInterface * i2c)
-: rclcpp::Node(node_name, node_options),
-  fd_(-1)
+: rclcpp::Node(node_name, node_options)
 {
   if (i2c == nullptr) {
     owned_i2c_ = std::make_unique<WiringPiI2C>();


### PR DESCRIPTION
## 概要

- #11 および #12 の対応

## 変更内容

### Issue #12: fd_ の二重初期化を解消

コンストラクタ初期化リストの `fd_(-1)` を削除。ヘッダ側のクラス内初期化子 (`int fd_ = -1`) のみで初期化を管理するよう統一した。

### Issue #11: テストノード名の重複を修正

全11テストケースで "test_node" というハードコードされたノード名を使用していたため、ROS2のノード名重複エラーが起きうる状態だった。

`testNodeName()` ヘルパー関数を追加し、GTestのテストスイート名とテストケース名から一意なノード名を生成するよう変更した。

### Issue #10: クローズ済み

PR #9 のマージ済みコードを確認したところ imuDataPublish() で既に gyro_.clear() / accel_.clear() が呼ばれており修正済みだったためクローズ。

## テスト計画

- [ ] ament_cmake_gtest による全11テストがパスすること
- [ ] ノード名重複によるエラーが出ないこと（テストの実行順を変えても安定して通ること）

Generated with [Claude Code](https://claude.com/claude-code)