### PR TITLE
feat: publish roll and pitch angles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if(BUILD_TESTING)
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   )
   target_link_libraries(test_mpu6050_driver mpu6050_driver_lib)
-  ament_target_dependencies(test_mpu6050_driver rclcpp sensor_msgs)
+  ament_target_dependencies(test_mpu6050_driver rclcpp sensor_msgs geometry_msgs)
 endif()
 
 ament_auto_package(

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ ros2 launch imu_driver mpu6050_driver.launch.xml publish_rate_hz:=200.0
 | Topic | Type | Description |
 |-------|------|-------------|
 | `output` | `sensor_msgs/Imu` | Raw IMU data (angular velocity + linear acceleration) |
+| `roll_pitch` | `geometry_msgs/Vector3Stamped` | Roll and pitch angles in degrees (`x=roll`, `y=pitch`, `z=0`) |
 
 ### Parameters
 

--- a/include/imu_driver/mpu6050_driver.hpp
+++ b/include/imu_driver/mpu6050_driver.hpp
@@ -17,6 +17,7 @@
 
 #include "imu_driver/i2c_interface.hpp"
 
+#include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
@@ -44,6 +45,7 @@ private:
   float get2data(int fd, unsigned int reg);
 
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr roll_pitch_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
   std::vector<float> gyro_;
   std::vector<float> accel_;

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
 
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
 
 
   <test_depend>ament_lint_auto</test_depend>

--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -59,6 +59,8 @@ Mpu6050Driver::Mpu6050Driver(
   const auto period_ms = static_cast<int64_t>(1000.0 / rate_hz);
 
   imu_pub_ = create_publisher<sensor_msgs::msg::Imu>("output", rclcpp::QoS{10});
+  roll_pitch_pub_ =
+    create_publisher<geometry_msgs::msg::Vector3Stamped>("roll_pitch", rclcpp::QoS{10});
   auto on_timer_ = std::bind(&Mpu6050Driver::onTimer, this);
   timer_ = std::make_shared<rclcpp::GenericTimer<decltype(on_timer_)>>(
     this->get_clock(), std::chrono::milliseconds(period_ms), std::move(on_timer_),
@@ -136,9 +138,14 @@ void Mpu6050Driver::imuDataPublish()
 
 void Mpu6050Driver::calcRollPitch()
 {
-  float roll = std::atan(accel_[1] / accel_[2]) * RAD_TO_DEG;
-  float pitch =
-    std::atan(-accel_[0] / std::sqrt(accel_[1] * accel_[1] + accel_[2] * accel_[2])) * RAD_TO_DEG;
-  (void)roll;
-  (void)pitch;
+  const float roll = std::atan2(accel_[1], accel_[2]) * RAD_TO_DEG;
+  const float pitch = std::atan2(-accel_[0], std::hypot(accel_[1], accel_[2])) * RAD_TO_DEG;
+
+  geometry_msgs::msg::Vector3Stamped msg;
+  msg.header.stamp = now();
+  msg.header.frame_id = "imu";
+  msg.vector.x = roll;
+  msg.vector.y = pitch;
+  msg.vector.z = 0.0f;
+  roll_pitch_pub_->publish(msg);
 }

--- a/test/test_mpu6050_driver.cpp
+++ b/test/test_mpu6050_driver.cpp
@@ -17,10 +17,12 @@
 #include "imu_driver/i2c_interface.hpp"
 #include "imu_driver/mpu6050_driver.hpp"
 
+#include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
 #include <chrono>
+#include <cmath>
 #include <map>
 #include <thread>
 
@@ -63,6 +65,25 @@ static sensor_msgs::msg::Imu::SharedPtr spinAndCapture(
   auto sub = node->create_subscription<sensor_msgs::msg::Imu>(
     "output", rclcpp::QoS{10},
     [&received](sensor_msgs::msg::Imu::SharedPtr msg) {
+      received = msg;
+    });
+
+  auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (!received && std::chrono::steady_clock::now() < deadline) {
+    rclcpp::spin_some(node);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  return received;
+}
+
+static geometry_msgs::msg::Vector3Stamped::SharedPtr spinAndCaptureRollPitch(
+  std::shared_ptr<Mpu6050Driver> node,
+  std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+{
+  geometry_msgs::msg::Vector3Stamped::SharedPtr received;
+  auto sub = node->create_subscription<geometry_msgs::msg::Vector3Stamped>(
+    "roll_pitch", rclcpp::QoS{10},
+    [&received](geometry_msgs::msg::Vector3Stamped::SharedPtr msg) {
       received = msg;
     });
 
@@ -263,6 +284,57 @@ TEST(Mpu6050DriverTest, AllAxesPublishedCorrectly)
   EXPECT_NEAR(msg->angular_velocity.x,    1.0f,     1e-4f);
   EXPECT_NEAR(msg->angular_velocity.y,    2.0f,     1e-4f);
   EXPECT_NEAR(msg->angular_velocity.z,    3.0f,     1e-4f);
+}
+
+TEST(Mpu6050DriverTest, RollPitchZeroWhenFlat)
+{
+  // Flat orientation: accel_x = 0, accel_y = 0, accel_z = 1g.
+  MockI2C mock;
+  mock.reg_values[0x3f] = 0x40;  // ACCEL_Z high byte => 16384 / 16384 = 1.0 g
+  mock.reg_values[0x40] = 0x00;  // ACCEL_Z low byte
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCaptureRollPitch(node);
+  ASSERT_NE(msg, nullptr) << "Expected a roll_pitch message to be published";
+  EXPECT_NEAR(msg->vector.x, 0.0f, 0.01f) << "Roll must be 0 when flat";
+  EXPECT_NEAR(msg->vector.y, 0.0f, 0.01f) << "Pitch must be 0 when flat";
+  EXPECT_EQ(msg->vector.z, 0.0f);
+  EXPECT_EQ(msg->header.frame_id, "imu");
+}
+
+TEST(Mpu6050DriverTest, RollFortyFiveDegrees)
+{
+  // accel_x = 0, accel_y = 1g, accel_z = 1g => roll = atan2(1, 1) = 45°.
+  MockI2C mock;
+  mock.reg_values[0x3d] = 0x40;  // ACCEL_Y high byte
+  mock.reg_values[0x3e] = 0x00;  // ACCEL_Y low byte
+  mock.reg_values[0x3f] = 0x40;  // ACCEL_Z high byte
+  mock.reg_values[0x40] = 0x00;  // ACCEL_Z low byte
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCaptureRollPitch(node);
+  ASSERT_NE(msg, nullptr);
+  EXPECT_NEAR(msg->vector.x, 45.0f, 0.01f) << "Roll must be 45° when accel_y == accel_z";
+  EXPECT_NEAR(msg->vector.y, 0.0f, 0.01f) << "Pitch must be 0 when accel_x == 0";
+}
+
+TEST(Mpu6050DriverTest, RollKeepsQuadrantWithNegativeZ)
+{
+  // accel_x = 0, accel_y = 1g, accel_z = -1g => atan2(1, -1) = 135°.
+  MockI2C mock;
+  mock.reg_values[0x3d] = 0x40;  // ACCEL_Y high byte => 1.0 g
+  mock.reg_values[0x3e] = 0x00;
+  mock.reg_values[0x3f] = 0xC0;  // ACCEL_Z high byte => -1.0 g
+  mock.reg_values[0x40] = 0x00;
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCaptureRollPitch(node);
+  ASSERT_NE(msg, nullptr);
+  EXPECT_NEAR(msg->vector.x, 135.0f, 0.01f) << "Roll must preserve quadrant information";
+  EXPECT_NEAR(msg->vector.y, 0.0f, 0.01f);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Publish the roll and pitch angles previously computed in `calcRollPitch()` on the `roll_pitch` topic.
- Use `geometry_msgs/msg/Vector3Stamped` with `x=roll`, `y=pitch`, and `z=0`.
- Include timestamps and the `imu` frame ID.
- Updated the branch after the earlier README and driver cleanup PRs were merged.

## Changes

| File | Change |
|---|---|
| `package.xml` | Added the `geometry_msgs` dependency. |
| `CMakeLists.txt` | Linked `geometry_msgs` for the driver test target. |
| `include/imu_driver/mpu6050_driver.hpp` | Added the `roll_pitch_pub_` publisher member and message include. |
| `src/mpu6050_driver_node.cpp` | Computes roll/pitch with `atan2` and `hypot`, then publishes `roll_pitch`. |
| `test/test_mpu6050_driver.cpp` | Added tests for flat orientation, 45 degree roll, and quadrant-preserving roll. |
| `README.md` | Documented the `roll_pitch` topic. |

## Review Fixes

- Removed the hard-coded `57.324f` conversion factor in favor of `RAD_TO_DEG`.
- Replaced division-based `atan()` expressions with `atan2()` and `hypot()` to preserve quadrants and avoid direct division by zero.
- Used specification-level expected values in tests instead of duplicating implementation constants.

## Verification

- GitHub Actions CI passed.
- `git diff --check` passed.
- Local `colcon test` was not run because ROS 2 / `colcon` is not installed in the local environment.
