### PR TITLE
docs: add installation and setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,100 @@
 # ros2_mpu6050_driver
-This repository assumes that you are using the MPU6050 with a Raspberry Pi.
 
-# Tested environment
-I have tested it in the following environment.
-- Raspberry Pi
-  - 3B+
-  - 4 (only build)
-- ubuntu
-  - 20.04
-  - 22.04 (only build)
-- ROS2
-  - foxy
-  - humble (only build)
+ROS2 driver for the MPU6050 IMU sensor (accelerometer + gyroscope), designed for use with a Raspberry Pi over I2C.
 
-# requirements
-- WiringPI
+## Tested Environment
 
-# Usage
-``` sh
-sudo chmod 777 /dev/ttyAMA0 # Give permissions to imu, select imu's device.
-ros2 launch imu_driver mpu6050_driver.launch.xml 
+| Component | Version |
+|-----------|---------|
+| Raspberry Pi | 3B+, 4 (build only) |
+| Ubuntu | 20.04, 22.04 (build only) |
+| ROS2 | Foxy, Humble (build only) |
+
+## Prerequisites
+
+### WiringPi
+
+Install WiringPi for I2C communication on Raspberry Pi:
+
+```sh
+# For Raspberry Pi OS / Ubuntu on RPi
+sudo apt-get install wiringpi
+
+# If the above doesn't work (newer Pi models), build from source:
+git clone https://github.com/WiringPi/WiringPi.git
+cd WiringPi
+./build
 ```
 
-# References
-I referred to the following.  
-https://shizenkarasuzon.hatenablog.com/entry/2019/03/06/163906
+Verify the installation:
+
+```sh
+gpio -v
+```
+
+### Enable I2C
+
+Enable I2C on Raspberry Pi:
+
+```sh
+sudo raspi-config
+# Navigate to: Interface Options > I2C > Enable
+```
+
+Verify the MPU6050 is detected (default address: `0x68`):
+
+```sh
+i2cdetect -y 1
+```
+
+## Installation
+
+```sh
+# Create a ROS2 workspace (skip if you already have one)
+mkdir -p ~/ros2_ws/src
+cd ~/ros2_ws/src
+
+# Clone this repository
+git clone https://github.com/1222-takeshi/ros2-mpu6050-driver.git
+
+# Install dependencies
+cd ~/ros2_ws
+rosdep install --from-paths src --ignore-src -r -y
+
+# Build
+colcon build --symlink-install
+
+# Source the workspace
+source install/setup.bash
+```
+
+## Usage
+
+```sh
+# Grant I2C permissions (run once per boot, or configure udev rules)
+sudo chmod 666 /dev/i2c-1
+
+# Launch the driver
+ros2 launch imu_driver mpu6050_driver.launch.xml
+```
+
+### Published Topics
+
+| Topic | Type | Description |
+|-------|------|-------------|
+| `output` | `sensor_msgs/Imu` | Raw IMU data (angular velocity + linear acceleration) |
+
+### Sensor Configuration
+
+The driver uses the following MPU6050 default settings:
+
+| Parameter | Value |
+|-----------|-------|
+| Gyroscope range | ±250°/s |
+| Accelerometer range | ±2g |
+| Output rate | 10 Hz |
+| I2C address | 0x68 |
+
+## References
+
+- [MPU6050 ROS2 driver reference](https://shizenkarasuzon.hatenablog.com/entry/2019/03/06/163906)

--- a/README.md
+++ b/README.md
@@ -6,21 +6,17 @@ ROS2 driver for the MPU6050 IMU sensor (accelerometer + gyroscope), designed for
 
 | Component | Version |
 |-----------|---------|
-| Raspberry Pi | 3B+, 4 (build only) |
-| Ubuntu | 20.04, 22.04 (build only) |
-| ROS2 | Foxy, Humble (build only) |
+| Raspberry Pi | 3B+, 4 |
+| Ubuntu | 22.04 |
+| ROS2 | Humble |
 
 ## Prerequisites
 
 ### WiringPi
 
-Install WiringPi for I2C communication on Raspberry Pi:
+On Ubuntu 22.04, WiringPi is not available via apt and must be built from source:
 
 ```sh
-# For Raspberry Pi OS / Ubuntu on RPi
-sudo apt-get install wiringpi
-
-# If the above doesn't work (newer Pi models), build from source:
 git clone https://github.com/WiringPi/WiringPi.git
 cd WiringPi
 ./build
@@ -34,11 +30,30 @@ gpio -v
 
 ### Enable I2C
 
-Enable I2C on Raspberry Pi:
+On Ubuntu 22.04, enable I2C by editing the boot configuration directly (`raspi-config` is not available):
 
 ```sh
-sudo raspi-config
-# Navigate to: Interface Options > I2C > Enable
+sudo nano /boot/firmware/config.txt
+```
+
+Add the following line:
+
+```
+dtparam=i2c_arm=on
+```
+
+Then reboot:
+
+```sh
+sudo reboot
+```
+
+Install i2c-tools and add your user to the `i2c` group (avoids `sudo` for every command):
+
+```sh
+sudo apt install i2c-tools
+sudo usermod -aG i2c $USER
+# Log out and back in for the group change to take effect
 ```
 
 Verify the MPU6050 is detected (default address: `0x68`):
@@ -71,10 +86,6 @@ source install/setup.bash
 ## Usage
 
 ```sh
-# Grant I2C permissions (run once per boot, or configure udev rules)
-sudo chmod 666 /dev/i2c-1
-
-# Launch the driver
 ros2 launch imu_driver mpu6050_driver.launch.xml
 ```
 


### PR DESCRIPTION
## Summary

Updated the README setup instructions for Raspberry Pi with Ubuntu 22.04 and ROS 2 Humble.

## Changes

### Tested Environment

Clarified the tested environment as Ubuntu 22.04 with ROS 2 Humble.

### Prerequisites: WiringPi

Replaced the apt-based WiringPi instruction with source build instructions, because WiringPi is not available through apt on Ubuntu 22.04.

```sh
git clone https://github.com/WiringPi/WiringPi.git
cd WiringPi
./build
```

### Prerequisites: Enable I2C

Replaced `raspi-config` guidance with direct edits to `/boot/firmware/config.txt`, which is the expected path on Ubuntu for Raspberry Pi.

```sh
sudo nano /boot/firmware/config.txt
# Add: dtparam=i2c_arm=on
sudo reboot
```

Added the `i2c` group setup so users do not need to change `/dev/i2c-1` permissions after each reboot.

```sh
sudo apt install i2c-tools
sudo usermod -aG i2c $USER
```

### Usage

Removed the temporary `sudo chmod 666 /dev/i2c-1` workaround and documented the persistent group-based setup instead.

## Related Issue

Closes #18
