### PR TITLE
fix: make IMU publish rate configurable (default 100 Hz)

### DIFF
--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -54,11 +54,14 @@ Mpu6050Driver::Mpu6050Driver(
     i2c_ = i2c;
   }
 
-  using std::chrono_literals::operator""ms;
+  declare_parameter<double>("publish_rate_hz", 100.0);
+  const double rate_hz = get_parameter("publish_rate_hz").as_double();
+  const auto period_ms = static_cast<int64_t>(1000.0 / rate_hz);
+
   imu_pub_ = create_publisher<sensor_msgs::msg::Imu>("output", rclcpp::QoS{10});
   auto on_timer_ = std::bind(&Mpu6050Driver::onTimer, this);
   timer_ = std::make_shared<rclcpp::GenericTimer<decltype(on_timer_)>>(
-    this->get_clock(), 100ms, std::move(on_timer_),
+    this->get_clock(), std::chrono::milliseconds(period_ms), std::move(on_timer_),
     this->get_node_base_interface()->get_context());
   this->get_node_timers_interface()->add_timer(timer_, nullptr);
 

--- a/test/test_mpu6050_driver.cpp
+++ b/test/test_mpu6050_driver.cpp
@@ -52,7 +52,7 @@ public:
 
 // ---------------------------------------------------------------------------
 // Helper: spin the node until a message arrives or timeout elapses.
-// The driver timer fires every 100 ms; we wait up to 1 s.
+// The driver timer fires at publish_rate_hz (default 100 Hz = 10 ms); we wait up to 1 s.
 // ---------------------------------------------------------------------------
 
 static sensor_msgs::msg::Imu::SharedPtr spinAndCapture(


### PR DESCRIPTION
## 概要

- タイマー周期がハードコードされた `100ms`（10Hz）から、`publish_rate_hz` パラメータ（デフォルト 100.0 Hz = 10ms）に変更
- Issue #177（inverted_pendulum）の修正：IMU 10Hz → 100Hz
- 既存テストはすべて通過（1秒タイムアウトは10ms周期でも十分）

## 変更ファイル

- `src/mpu6050_driver_node.cpp`: タイマー周期をパラメータ化
- `test/test_mpu6050_driver.cpp`: コメントを実態に合わせて更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)