### PR TITLE
docs: publish_rate_hz の既定値を README に反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,25 @@ source install/setup.bash
 ros2 launch imu_driver mpu6050_driver.launch.xml
 ```
 
+The publish rate is controlled by the `publish_rate_hz` parameter. The default is `100.0` Hz.
+
+Example override:
+
+```sh
+ros2 launch imu_driver mpu6050_driver.launch.xml publish_rate_hz:=200.0
+```
+
 ### Published Topics
 
 | Topic | Type | Description |
 |-------|------|-------------|
 | `output` | `sensor_msgs/Imu` | Raw IMU data (angular velocity + linear acceleration) |
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `publish_rate_hz` | double | `100.0` | IMU publish rate in Hz |
 
 ### Sensor Configuration
 
@@ -103,7 +117,7 @@ The driver uses the following MPU6050 default settings:
 |-----------|-------|
 | Gyroscope range | ±250°/s |
 | Accelerometer range | ±2g |
-| Output rate | 10 Hz |
+| Output rate | 100 Hz by default (`publish_rate_hz`) |
 | I2C address | 0x68 |
 
 ## References

--- a/launch/mpu6050_driver.launch.xml
+++ b/launch/mpu6050_driver.launch.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="output_imu_name" default="/imu/data_raw" description="output imu raw data" />
+  <arg name="publish_rate_hz" default="100.0" description="IMU publish rate in Hz" />
 
   <node name="imu_driver" pkg="imu_driver" exec="imu_driver">
+    <param name="publish_rate_hz" value="$(var publish_rate_hz)" />
     <remap from="output" to="$(var output_imu_name)"/>
   </node>
 </launch>


### PR DESCRIPTION
## 目的

`publish_rate_hz` の実装既定値は `100.0` Hz ですが、README の Sensor Configuration では Output rate が `10 Hz` のままになっていました。
また、launch ファイル側で `publish_rate_hz` を引数として渡せなかったため、README の上書き例が実際に使えるように launch 設定も合わせます。

## 変更内容

- README の Usage に `publish_rate_hz` パラメータの説明を追加
- README に 200Hz へ上書きする起動例を追加
- README に Parameters 表を追加
- Sensor Configuration の Output rate を `100 Hz by default (publish_rate_hz)` に更新
- `launch/mpu6050_driver.launch.xml` に `publish_rate_hz` 引数を追加し、node parameter として渡すように変更

## 確認方法

- GitHub コネクタで変更後の `README.md` と `launch/mpu6050_driver.launch.xml` をブランチから読み戻し、記載・設定内容を確認しました。
- ローカルでは ROS2/colcon 環境を起動できないため、`colcon test` は未実行です。
- PR の GitHub Actions CI でビルド・テスト結果を確認してください。

## リスク

- 実装 C++ コードは変更していません。
- launch 引数の既定値はノード実装の既定値と同じ `100.0` に揃えています。

## 関連 Issue

- 1222-takeshi/inverted_pendulum#177

🤖 Generated with Codex automation