### PR TITLE
[codex] fix publish_rate_hz validation

### DIFF
--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -18,6 +18,7 @@
 #include <rclcpp/timer.hpp>
 
 #include <cmath>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
@@ -40,6 +41,8 @@ static constexpr float GYRO_SENSITIVITY_LSB = 131.0f;
 static constexpr float ACCEL_SENSITIVITY_LSB = 16384.0f;
 // Radians to degrees conversion factor
 static constexpr float RAD_TO_DEG = 180.0f / M_PI;
+static constexpr double DEFAULT_PUBLISH_RATE_HZ = 100.0;
+static constexpr int64_t MIN_TIMER_PERIOD_MS = 1;
 
 Mpu6050Driver::Mpu6050Driver(
   const std::string & node_name,
@@ -54,9 +57,21 @@ Mpu6050Driver::Mpu6050Driver(
     i2c_ = i2c;
   }
 
-  declare_parameter<double>("publish_rate_hz", 100.0);
-  const double rate_hz = get_parameter("publish_rate_hz").as_double();
-  const auto period_ms = static_cast<int64_t>(1000.0 / rate_hz);
+  declare_parameter<double>("publish_rate_hz", DEFAULT_PUBLISH_RATE_HZ);
+  double rate_hz = get_parameter("publish_rate_hz").as_double();
+  if (!std::isfinite(rate_hz) || rate_hz <= 0.0) {
+    RCLCPP_ERROR(
+      get_logger(), "Invalid publish_rate_hz %.3f; falling back to %.1f Hz", rate_hz,
+      DEFAULT_PUBLISH_RATE_HZ);
+    rate_hz = DEFAULT_PUBLISH_RATE_HZ;
+  }
+
+  auto period_ms = static_cast<int64_t>(1000.0 / rate_hz);
+  if (period_ms < MIN_TIMER_PERIOD_MS) {
+    RCLCPP_WARN(
+      get_logger(), "publish_rate_hz %.3f is above timer resolution; using 1 ms period", rate_hz);
+    period_ms = MIN_TIMER_PERIOD_MS;
+  }
 
   imu_pub_ = create_publisher<sensor_msgs::msg::Imu>("output", rclcpp::QoS{10});
   auto on_timer_ = std::bind(&Mpu6050Driver::onTimer, this);

--- a/test/test_mpu6050_driver.cpp
+++ b/test/test_mpu6050_driver.cpp
@@ -86,6 +86,13 @@ static std::string testNodeName()
   return std::string("test_") + info->test_suite_name() + "_" + info->name();
 }
 
+static rclcpp::NodeOptions optionsWithPublishRate(double rate_hz)
+{
+  rclcpp::NodeOptions opts;
+  opts.parameter_overrides({rclcpp::Parameter("publish_rate_hz", rate_hz)});
+  return opts;
+}
+
 TEST(Mpu6050DriverTest, WakesDeviceFromSleepOnInit)
 {
   // PWR_MGMT_1 (0x6B) must be written with 0x00 to wake MPU6050 from sleep.
@@ -122,6 +129,38 @@ TEST(Mpu6050DriverTest, DoesNotWritePwrMgmtWhenSetupFails)
 
   EXPECT_EQ(mock.written_regs.count(0x6B), 0u)
     << "PWR_MGMT_1 must not be written when I2C setup failed";
+}
+
+TEST(Mpu6050DriverTest, FallsBackToDefaultPublishRateWhenZero)
+{
+  MockI2C mock;
+  auto opts = optionsWithPublishRate(0.0);
+  std::shared_ptr<Mpu6050Driver> node;
+
+  ASSERT_NO_THROW({node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);});
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr) << "Invalid publish_rate_hz must fall back and still publish";
+}
+
+TEST(Mpu6050DriverTest, FallsBackToDefaultPublishRateWhenNegative)
+{
+  MockI2C mock;
+  auto opts = optionsWithPublishRate(-10.0);
+  std::shared_ptr<Mpu6050Driver> node;
+
+  ASSERT_NO_THROW({node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);});
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr) << "Negative publish_rate_hz must fall back and still publish";
+}
+
+TEST(Mpu6050DriverTest, AcceptsPositivePublishRateOverride)
+{
+  MockI2C mock;
+  auto opts = optionsWithPublishRate(200.0);
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr) << "Positive publish_rate_hz override must keep publishing";
 }
 
 TEST(Mpu6050DriverTest, PositiveAccelValueConvertedCorrectly)


### PR DESCRIPTION
## 概要

Issue #25 の対応として、`publish_rate_hz` パラメータの入力検証を追加しました。

## 変更内容

- `publish_rate_hz` が `0` 以下または非有限値の場合、ERROR ログを出して既定値 `100.0` Hz にフォールバック
- 極端に高い値でタイマー周期が `0ms` になる場合、WARN ログを出して `1ms` に clamp
- `publish_rate_hz:=0.0` / `publish_rate_hz:=-10.0` / `publish_rate_hz:=200.0` の gtest を追加

## 確認

- GitHub コネクタで branch 上の `src/mpu6050_driver_node.cpp` と `test/test_mpu6050_driver.cpp` を読み戻し、変更反映を確認しました。
- この環境には ROS2/colcon のローカルチェックアウトがないため、`colcon test` は未実行です。GitHub Actions CI の結果を確認してください。

Closes #25

🤖 Generated with Codex automation