### PR TITLE
refactor: use fixed-size IMU sample buffers

### DIFF
--- a/include/imu_driver/mpu6050_driver.hpp
+++ b/include/imu_driver/mpu6050_driver.hpp
@@ -20,9 +20,9 @@
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
+#include <array>
 #include <memory>
 #include <string>
-#include <vector>
 
 class Mpu6050Driver : public rclcpp::Node
 {
@@ -45,8 +45,8 @@ private:
 
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
-  std::vector<float> gyro_;
-  std::vector<float> accel_;
+  std::array<float, 3> gyro_{};
+  std::array<float, 3> accel_{};
 
   std::unique_ptr<II2CInterface> owned_i2c_;  ///< Owns the instance when created internally.
   II2CInterface * i2c_;                        ///< Non-owning pointer used for all I2C calls.

--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -108,16 +108,20 @@ void Mpu6050Driver::onTimer()
 
 void Mpu6050Driver::updateCurrentGyroData()
 {
-  gyro_.push_back(get2data(fd_, GYRO_X_OUT) / GYRO_SENSITIVITY_LSB);
-  gyro_.push_back(get2data(fd_, GYRO_Y_OUT) / GYRO_SENSITIVITY_LSB);
-  gyro_.push_back(get2data(fd_, GYRO_Z_OUT) / GYRO_SENSITIVITY_LSB);
+  gyro_ = {{
+    get2data(fd_, GYRO_X_OUT) / GYRO_SENSITIVITY_LSB,
+    get2data(fd_, GYRO_Y_OUT) / GYRO_SENSITIVITY_LSB,
+    get2data(fd_, GYRO_Z_OUT) / GYRO_SENSITIVITY_LSB,
+  }};
 }
 
 void Mpu6050Driver::updateCurrentAccelData()
 {
-  accel_.push_back(get2data(fd_, ACCEL_X_OUT) / ACCEL_SENSITIVITY_LSB);
-  accel_.push_back(get2data(fd_, ACCEL_Y_OUT) / ACCEL_SENSITIVITY_LSB);
-  accel_.push_back(get2data(fd_, ACCEL_Z_OUT) / ACCEL_SENSITIVITY_LSB);
+  accel_ = {{
+    get2data(fd_, ACCEL_X_OUT) / ACCEL_SENSITIVITY_LSB,
+    get2data(fd_, ACCEL_Y_OUT) / ACCEL_SENSITIVITY_LSB,
+    get2data(fd_, ACCEL_Z_OUT) / ACCEL_SENSITIVITY_LSB,
+  }};
 }
 
 float Mpu6050Driver::get2data(int fd, unsigned int reg)
@@ -145,8 +149,6 @@ void Mpu6050Driver::imuDataPublish()
   msg.linear_acceleration.y = accel_[1];
   msg.linear_acceleration.z = accel_[2];
   imu_pub_->publish(msg);
-  gyro_.clear();
-  accel_.clear();
 }
 
 void Mpu6050Driver::calcRollPitch()


### PR DESCRIPTION
## Summary

MPU6050 IMU samples always contain three gyro axes and three accel axes. The driver does not need dynamically sized vectors that are appended and cleared on every publish cycle.

This refactor stores gyro and accel samples in fixed-size arrays to remove unnecessary dynamic buffer operations from the publish loop.

## Changes

- Replaced `gyro_` and `accel_` from `std::vector<float>` with `std::array<float, 3>`.
- Updated `updateCurrentGyroData()` and `updateCurrentAccelData()` to assign all three axis values directly.
- Removed `clear()` calls after publishing.

## Verification

- Confirmed the PR only changes `include/imu_driver/mpu6050_driver.hpp` and `src/mpu6050_driver_node.cpp`.
- `git diff --check` passed.
- GitHub Actions CI passed.
- Local `colcon test` was not run because ROS 2 / `colcon` is not installed in the local environment.

## Risk

- The published topic values, axis order, and scaling behavior are unchanged.
