### PR TITLE
feat: add MPU6050 diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,13 @@ if(BUILD_TESTING)
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   )
   target_link_libraries(test_mpu6050_driver mpu6050_driver_lib)
-  ament_target_dependencies(test_mpu6050_driver rclcpp sensor_msgs geometry_msgs diagnostic_msgs)
+  ament_target_dependencies(test_mpu6050_driver
+    rclcpp
+    sensor_msgs
+    geometry_msgs
+    diagnostic_msgs
+    diagnostic_updater
+  )
 endif()
 
 ament_auto_package(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if(BUILD_TESTING)
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   )
   target_link_libraries(test_mpu6050_driver mpu6050_driver_lib)
-  ament_target_dependencies(test_mpu6050_driver rclcpp sensor_msgs)
+  ament_target_dependencies(test_mpu6050_driver rclcpp sensor_msgs diagnostic_msgs)
 endif()
 
 ament_auto_package(

--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ ros2 launch imu_driver mpu6050_driver.launch.xml publish_rate_hz:=200.0
 |-------|------|-------------|
 | `output` | `sensor_msgs/Imu` | Raw IMU data (angular velocity + linear acceleration) |
 | `roll_pitch` | `geometry_msgs/Vector3Stamped` | Roll and pitch angles in degrees (`x=roll`, `y=pitch`, `z=0`) |
+| `/diagnostics` | `diagnostic_msgs/DiagnosticArray` | Driver health status for ROS diagnostics tools |
+
+### Diagnostics
+
+The driver publishes two diagnostic statuses:
+
+| Status | OK | WARN | ERROR |
+|--------|----|------|-------|
+| `Hardware Status` | I2C is initialized, temperature is normal, and all axes are active | Chip temperature is above 70°C or one or more axes are in standby | I2C is not initialized, an I2C register read fails, or chip temperature is above 85°C |
+| `Data Status` | IMU samples are recent and within the expected range | No sample has been published yet, the latest sample is stale, or the latest sample is outside the expected range | I2C is not initialized or the latest sample read failed |
+
+You can inspect the diagnostics with:
+
+```sh
+ros2 topic echo /diagnostics
+```
 
 ### Parameters
 

--- a/include/imu_driver/mpu6050_driver.hpp
+++ b/include/imu_driver/mpu6050_driver.hpp
@@ -40,14 +40,15 @@ public:
 private:
   void initializeI2C();
   void onTimer();
-  void updateCurrentGyroData();
-  void updateCurrentAccelData();
+  bool updateCurrentGyroData();
+  bool updateCurrentAccelData();
   void calcRollPitch();
   void imuDataPublish();
   void checkHardwareStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void checkDataStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
   bool isLatestSampleValid() const;
-  float get2data(int fd, unsigned int reg);
+  bool readReg8Checked(int fd, unsigned int reg, int * value);
+  bool read2data(int fd, unsigned int reg, float * value);
 
   diagnostic_updater::Updater diagnostic_updater_;
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
@@ -58,6 +59,7 @@ private:
   rclcpp::Time last_sample_time_;
   double publish_rate_hz_ = 0.0;
   std::size_t sample_count_ = 0;
+  bool latest_sample_read_ok_ = true;
   bool latest_sample_valid_ = false;
 
   std::unique_ptr<II2CInterface> owned_i2c_;  ///< Owns the instance when created internally.

--- a/include/imu_driver/mpu6050_driver.hpp
+++ b/include/imu_driver/mpu6050_driver.hpp
@@ -17,10 +17,12 @@
 
 #include "imu_driver/i2c_interface.hpp"
 
+#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
 #include <array>
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -41,12 +43,20 @@ private:
   void updateCurrentAccelData();
   void calcRollPitch();
   void imuDataPublish();
+  void checkHardwareStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void checkDataStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  bool isLatestSampleValid() const;
   float get2data(int fd, unsigned int reg);
 
+  diagnostic_updater::Updater diagnostic_updater_;
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
   std::array<float, 3> gyro_{};
   std::array<float, 3> accel_{};
+  rclcpp::Time last_sample_time_;
+  double publish_rate_hz_ = 0.0;
+  std::size_t sample_count_ = 0;
+  bool latest_sample_valid_ = false;
 
   std::unique_ptr<II2CInterface> owned_i2c_;  ///< Owns the instance when created internally.
   II2CInterface * i2c_;                        ///< Non-owning pointer used for all I2C calls.

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,8 @@
 
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>diagnostic_updater</depend>
 
 
   <test_depend>ament_lint_auto</test_depend>

--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -15,6 +15,7 @@
 #include "imu_driver/mpu6050_driver.hpp"
 #include "imu_driver/wiringpi_i2c.hpp"
 
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <rclcpp/timer.hpp>
 
 #include <cmath>
@@ -43,12 +44,18 @@ static constexpr float ACCEL_SENSITIVITY_LSB = 16384.0f;
 static constexpr float RAD_TO_DEG = 180.0f / M_PI;
 static constexpr double DEFAULT_PUBLISH_RATE_HZ = 100.0;
 static constexpr int64_t MIN_TIMER_PERIOD_MS = 1;
+static constexpr float TEMP_WARN_C = 70.0f;
+static constexpr float TEMP_ERROR_C = 85.0f;
+static constexpr float MAX_ACCEL_G = 2.5f;
+static constexpr float MAX_GYRO_DPS = 260.0f;
+static constexpr double STALE_SAMPLE_PERIOD_MULTIPLIER = 3.0;
 
 Mpu6050Driver::Mpu6050Driver(
   const std::string & node_name,
   const rclcpp::NodeOptions & node_options,
   II2CInterface * i2c)
-: rclcpp::Node(node_name, node_options)
+: rclcpp::Node(node_name, node_options),
+  diagnostic_updater_(this)
 {
   if (i2c == nullptr) {
     owned_i2c_ = std::make_unique<WiringPiI2C>();
@@ -72,6 +79,7 @@ Mpu6050Driver::Mpu6050Driver(
       get_logger(), "publish_rate_hz %.3f is above timer resolution; using 1 ms period", rate_hz);
     period_ms = MIN_TIMER_PERIOD_MS;
   }
+  publish_rate_hz_ = rate_hz;
 
   imu_pub_ = create_publisher<sensor_msgs::msg::Imu>("output", rclcpp::QoS{10});
   auto on_timer_ = std::bind(&Mpu6050Driver::onTimer, this);
@@ -79,6 +87,10 @@ Mpu6050Driver::Mpu6050Driver(
     this->get_clock(), std::chrono::milliseconds(period_ms), std::move(on_timer_),
     this->get_node_base_interface()->get_context());
   this->get_node_timers_interface()->add_timer(timer_, nullptr);
+
+  diagnostic_updater_.setHardwareID("MPU6050");
+  diagnostic_updater_.add("Hardware Status", this, &Mpu6050Driver::checkHardwareStatus);
+  diagnostic_updater_.add("Data Status", this, &Mpu6050Driver::checkDataStatus);
 
   initializeI2C();
 }
@@ -140,7 +152,11 @@ float Mpu6050Driver::get2data(int fd, unsigned int reg)
 void Mpu6050Driver::imuDataPublish()
 {
   sensor_msgs::msg::Imu msg;
-  msg.header.stamp = now();
+  last_sample_time_ = now();
+  latest_sample_valid_ = isLatestSampleValid();
+  ++sample_count_;
+
+  msg.header.stamp = last_sample_time_;
   msg.header.frame_id = "imu";
   msg.angular_velocity.x = gyro_[0];
   msg.angular_velocity.y = gyro_[1];
@@ -158,4 +174,79 @@ void Mpu6050Driver::calcRollPitch()
     std::atan(-accel_[0] / std::sqrt(accel_[1] * accel_[1] + accel_[2] * accel_[2])) * RAD_TO_DEG;
   (void)roll;
   (void)pitch;
+}
+
+void Mpu6050Driver::checkHardwareStatus(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  using diagnostic_msgs::msg::DiagnosticStatus;
+
+  stat.add("I2C connection", fd_ == -1 ? "not initialized" : "ok");
+  stat.add("Gyro sensitivity", "131 LSB/(deg/s) [+-250 deg/s]");
+  stat.add("Accel sensitivity", "16384 LSB/g [+-2g]");
+
+  if (fd_ == -1) {
+    stat.summary(DiagnosticStatus::ERROR, "I2C not initialized");
+    return;
+  }
+
+  const float temp_c = get2data(fd_, TEMP_OUT) / 340.0f + 36.53f;
+  const int pwr_mgmt_2 = i2c_->readReg8(fd_, PWR_MGMT_2);
+  const bool all_axes_active = (pwr_mgmt_2 & 0x3F) == 0x00;
+
+  stat.add("Chip temperature C", temp_c);
+  stat.add("PWR_MGMT_2", pwr_mgmt_2);
+  stat.add("Axis power state", all_axes_active ? "all active" : "some axes in standby");
+
+  if (temp_c > TEMP_ERROR_C) {
+    stat.summary(DiagnosticStatus::ERROR, "Chip overheating");
+  } else if (temp_c > TEMP_WARN_C || !all_axes_active) {
+    stat.summary(DiagnosticStatus::WARN, "Sensor degraded");
+  } else {
+    stat.summary(DiagnosticStatus::OK, "Hardware OK");
+  }
+}
+
+void Mpu6050Driver::checkDataStatus(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  using diagnostic_msgs::msg::DiagnosticStatus;
+
+  stat.add("Configured publish_rate_hz", publish_rate_hz_);
+  stat.add("Published samples", sample_count_);
+
+  if (fd_ == -1) {
+    stat.summary(DiagnosticStatus::ERROR, "I2C not initialized");
+    return;
+  }
+  if (sample_count_ == 0) {
+    stat.summary(DiagnosticStatus::WARN, "No IMU samples published yet");
+    return;
+  }
+
+  const double sample_age_s = (now() - last_sample_time_).seconds();
+  const double expected_period_s = 1.0 / publish_rate_hz_;
+  stat.add("Latest sample age sec", sample_age_s);
+  stat.add("Latest sample valid", latest_sample_valid_);
+
+  if (!latest_sample_valid_) {
+    stat.summary(DiagnosticStatus::WARN, "Latest IMU sample outside expected range");
+  } else if (sample_age_s > expected_period_s * STALE_SAMPLE_PERIOD_MULTIPLIER) {
+    stat.summary(DiagnosticStatus::WARN, "No recent IMU sample");
+  } else {
+    stat.summary(DiagnosticStatus::OK, "Data OK");
+  }
+}
+
+bool Mpu6050Driver::isLatestSampleValid() const
+{
+  for (const auto value : accel_) {
+    if (!std::isfinite(value) || std::fabs(value) > MAX_ACCEL_G) {
+      return false;
+    }
+  }
+  for (const auto value : gyro_) {
+    if (!std::isfinite(value) || std::fabs(value) > MAX_GYRO_DPS) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -114,41 +114,78 @@ void Mpu6050Driver::onTimer()
     RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "I2C not initialized, skipping update");
     return;
   }
-  updateCurrentGyroData();
-  updateCurrentAccelData();
+  latest_sample_read_ok_ = updateCurrentGyroData() && updateCurrentAccelData();
+  if (!latest_sample_read_ok_) {
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "I2C register read failed, skipping update");
+    return;
+  }
   calcRollPitch();
   imuDataPublish();
 }
 
-void Mpu6050Driver::updateCurrentGyroData()
+bool Mpu6050Driver::updateCurrentGyroData()
 {
+  float gyro_x = 0.0f;
+  float gyro_y = 0.0f;
+  float gyro_z = 0.0f;
+  const bool read_ok =
+    read2data(fd_, GYRO_X_OUT, &gyro_x) &&
+    read2data(fd_, GYRO_Y_OUT, &gyro_y) &&
+    read2data(fd_, GYRO_Z_OUT, &gyro_z);
+  if (!read_ok) {
+    return false;
+  }
   gyro_ = {{
-    get2data(fd_, GYRO_X_OUT) / GYRO_SENSITIVITY_LSB,
-    get2data(fd_, GYRO_Y_OUT) / GYRO_SENSITIVITY_LSB,
-    get2data(fd_, GYRO_Z_OUT) / GYRO_SENSITIVITY_LSB,
+    gyro_x / GYRO_SENSITIVITY_LSB,
+    gyro_y / GYRO_SENSITIVITY_LSB,
+    gyro_z / GYRO_SENSITIVITY_LSB,
   }};
+  return true;
 }
 
-void Mpu6050Driver::updateCurrentAccelData()
+bool Mpu6050Driver::updateCurrentAccelData()
 {
+  float accel_x = 0.0f;
+  float accel_y = 0.0f;
+  float accel_z = 0.0f;
+  const bool read_ok =
+    read2data(fd_, ACCEL_X_OUT, &accel_x) &&
+    read2data(fd_, ACCEL_Y_OUT, &accel_y) &&
+    read2data(fd_, ACCEL_Z_OUT, &accel_z);
+  if (!read_ok) {
+    return false;
+  }
   accel_ = {{
-    get2data(fd_, ACCEL_X_OUT) / ACCEL_SENSITIVITY_LSB,
-    get2data(fd_, ACCEL_Y_OUT) / ACCEL_SENSITIVITY_LSB,
-    get2data(fd_, ACCEL_Z_OUT) / ACCEL_SENSITIVITY_LSB,
+    accel_x / ACCEL_SENSITIVITY_LSB,
+    accel_y / ACCEL_SENSITIVITY_LSB,
+    accel_z / ACCEL_SENSITIVITY_LSB,
   }};
+  return true;
 }
 
-float Mpu6050Driver::get2data(int fd, unsigned int reg)
+bool Mpu6050Driver::readReg8Checked(int fd, unsigned int reg, int * value)
 {
-  unsigned int h_value = static_cast<unsigned int>(i2c_->readReg8(fd, reg));
-  unsigned int l_value = static_cast<unsigned int>(i2c_->readReg8(fd, reg + 1));
-  float value = static_cast<float>((h_value << 8) + l_value);
+  const int raw_value = i2c_->readReg8(fd, static_cast<int>(reg));
+  if (raw_value < 0 || raw_value > 0xFF) {
+    return false;
+  }
+  *value = raw_value;
+  return true;
+}
+
+bool Mpu6050Driver::read2data(int fd, unsigned int reg, float * value)
+{
+  int h_value = 0;
+  int l_value = 0;
+  if (!readReg8Checked(fd, reg, &h_value) || !readReg8Checked(fd, reg + 1, &l_value)) {
+    return false;
+  }
+
+  const int raw_value = (h_value << 8) + l_value;
   // Convert from unsigned 16-bit to signed using two's complement.
   // Values >= 32768 (0x8000) represent negative numbers.
-  if (value >= 32768.0f) {
-    return value - 65536.0f;  // 0x10000 = 65536
-  }
-  return value;
+  *value = static_cast<float>(raw_value >= 32768 ? raw_value - 65536 : raw_value);
+  return true;
 }
 
 void Mpu6050Driver::imuDataPublish()
@@ -196,8 +233,15 @@ void Mpu6050Driver::checkHardwareStatus(diagnostic_updater::DiagnosticStatusWrap
     return;
   }
 
-  const float temp_c = get2data(fd_, TEMP_OUT) / 340.0f + 36.53f;
-  const int pwr_mgmt_2 = i2c_->readReg8(fd_, PWR_MGMT_2);
+  float temp_raw = 0.0f;
+  int pwr_mgmt_2 = 0;
+  if (!read2data(fd_, TEMP_OUT, &temp_raw) || !readReg8Checked(fd_, PWR_MGMT_2, &pwr_mgmt_2)) {
+    stat.add("I2C register reads", "failed");
+    stat.summary(DiagnosticStatus::ERROR, "I2C read failed");
+    return;
+  }
+
+  const float temp_c = temp_raw / 340.0f + 36.53f;
   const bool all_axes_active = (pwr_mgmt_2 & 0x3F) == 0x00;
 
   stat.add("Chip temperature C", temp_c);
@@ -222,6 +266,11 @@ void Mpu6050Driver::checkDataStatus(diagnostic_updater::DiagnosticStatusWrapper 
 
   if (fd_ == -1) {
     stat.summary(DiagnosticStatus::ERROR, "I2C not initialized");
+    return;
+  }
+  stat.add("Latest I2C read ok", latest_sample_read_ok_);
+  if (!latest_sample_read_ok_) {
+    stat.summary(DiagnosticStatus::ERROR, "I2C read failed");
     return;
   }
   if (sample_count_ == 0) {

--- a/test/test_mpu6050_driver.cpp
+++ b/test/test_mpu6050_driver.cpp
@@ -17,11 +17,14 @@
 #include "imu_driver/i2c_interface.hpp"
 #include "imu_driver/mpu6050_driver.hpp"
 
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
 #include <chrono>
 #include <map>
+#include <string>
 #include <thread>
 
 // ---------------------------------------------------------------------------
@@ -72,6 +75,33 @@ static sensor_msgs::msg::Imu::SharedPtr spinAndCapture(
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   return received;
+}
+
+static bool spinAndCaptureDiagnosticStatus(
+  std::shared_ptr<Mpu6050Driver> node,
+  const std::string & status_name,
+  diagnostic_msgs::msg::DiagnosticStatus * received,
+  std::chrono::milliseconds timeout = std::chrono::milliseconds(2500))
+{
+  bool found = false;
+  auto sub = node->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+    "/diagnostics", rclcpp::QoS{10},
+    [&found, &received, &status_name](diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg) {
+      for (const auto & status : msg->status) {
+        if (status.name.find(status_name) != std::string::npos) {
+          *received = status;
+          found = true;
+          return;
+        }
+      }
+    });
+
+  auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (!found && std::chrono::steady_clock::now() < deadline) {
+    rclcpp::spin_some(node);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  return found;
 }
 
 // ---------------------------------------------------------------------------
@@ -129,6 +159,63 @@ TEST(Mpu6050DriverTest, DoesNotWritePwrMgmtWhenSetupFails)
 
   EXPECT_EQ(mock.written_regs.count(0x6B), 0u)
     << "PWR_MGMT_1 must not be written when I2C setup failed";
+}
+
+TEST(Mpu6050DriverTest, PublishesHardwareDiagnosticOk)
+{
+  MockI2C mock;
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  ASSERT_TRUE(spinAndCaptureDiagnosticStatus(node, "Hardware Status", &status))
+    << "Expected a hardware diagnostic status";
+  EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+  EXPECT_EQ(status.hardware_id, "MPU6050");
+}
+
+TEST(Mpu6050DriverTest, PublishesHardwareDiagnosticErrorWhenI2CSetupFails)
+{
+  MockI2C mock;
+  mock.setup_return_value = -1;
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  ASSERT_TRUE(spinAndCaptureDiagnosticStatus(node, "Hardware Status", &status))
+    << "Expected a hardware diagnostic status";
+  EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_EQ(status.message, "I2C not initialized");
+}
+
+TEST(Mpu6050DriverTest, PublishesHardwareDiagnosticWarnWhenAxisInStandby)
+{
+  MockI2C mock;
+  mock.reg_values[0x6C] = 0x01;  // PWR_MGMT_2: accel Z standby bit set
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  ASSERT_TRUE(spinAndCaptureDiagnosticStatus(node, "Hardware Status", &status))
+    << "Expected a hardware diagnostic status";
+  EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  EXPECT_EQ(status.message, "Sensor degraded");
+}
+
+TEST(Mpu6050DriverTest, PublishesDataDiagnosticOkAfterSample)
+{
+  MockI2C mock;
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto imu_msg = spinAndCapture(node);
+  ASSERT_NE(imu_msg, nullptr);
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  ASSERT_TRUE(spinAndCaptureDiagnosticStatus(node, "Data Status", &status))
+    << "Expected a data diagnostic status";
+  EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+  EXPECT_EQ(status.message, "Data OK");
 }
 
 TEST(Mpu6050DriverTest, FallsBackToDefaultPublishRateWhenZero)

--- a/test/test_mpu6050_driver.cpp
+++ b/test/test_mpu6050_driver.cpp
@@ -223,6 +223,52 @@ TEST(Mpu6050DriverTest, PublishesHardwareDiagnosticWarnWhenAxisInStandby)
   EXPECT_EQ(status.message, "Sensor degraded");
 }
 
+TEST(Mpu6050DriverTest, PublishesHardwareDiagnosticWarnWhenTemperatureHigh)
+{
+  MockI2C mock;
+  // TEMP_OUT raw = 0x2D28 = 11560 => 11560 / 340 + 36.53 = 70.53 C.
+  mock.reg_values[0x41] = 0x2D;
+  mock.reg_values[0x42] = 0x28;
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  ASSERT_TRUE(spinAndCaptureDiagnosticStatus(node, "Hardware Status", &status))
+    << "Expected a hardware diagnostic status";
+  EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  EXPECT_EQ(status.message, "Sensor degraded");
+}
+
+TEST(Mpu6050DriverTest, PublishesHardwareDiagnosticErrorWhenTemperatureCritical)
+{
+  MockI2C mock;
+  // TEMP_OUT raw = 0x4114 = 16660 => 16660 / 340 + 36.53 = 85.53 C.
+  mock.reg_values[0x41] = 0x41;
+  mock.reg_values[0x42] = 0x14;
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  ASSERT_TRUE(spinAndCaptureDiagnosticStatus(node, "Hardware Status", &status))
+    << "Expected a hardware diagnostic status";
+  EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_EQ(status.message, "Chip overheating");
+}
+
+TEST(Mpu6050DriverTest, PublishesHardwareDiagnosticErrorWhenRegisterReadFails)
+{
+  MockI2C mock;
+  mock.reg_values[0x41] = -1;  // TEMP_OUT high byte read failure
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  ASSERT_TRUE(spinAndCaptureDiagnosticStatus(node, "Hardware Status", &status))
+    << "Expected a hardware diagnostic status";
+  EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_EQ(status.message, "I2C read failed");
+}
+
 TEST(Mpu6050DriverTest, PublishesDataDiagnosticOkAfterSample)
 {
   MockI2C mock;
@@ -237,6 +283,20 @@ TEST(Mpu6050DriverTest, PublishesDataDiagnosticOkAfterSample)
     << "Expected a data diagnostic status";
   EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
   EXPECT_EQ(status.message, "Data OK");
+}
+
+TEST(Mpu6050DriverTest, PublishesDataDiagnosticErrorWhenSampleReadFails)
+{
+  MockI2C mock;
+  mock.reg_values[0x43] = -1;  // GYRO_X high byte read failure
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  ASSERT_TRUE(spinAndCaptureDiagnosticStatus(node, "Data Status", &status))
+    << "Expected a data diagnostic status";
+  EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_EQ(status.message, "I2C read failed");
 }
 
 TEST(Mpu6050DriverTest, FallsBackToDefaultPublishRateWhenZero)


### PR DESCRIPTION
## Summary

Adds ROS 2 diagnostics support for the MPU6050 driver using `diagnostic_updater`.

The driver now publishes `Hardware Status` and `Data Status` entries on `/diagnostics`, making I2C setup failures, register read failures, chip temperature, axis standby state, and sample health visible to ROS diagnostics tools.

## Changes

- Added `diagnostic_updater` and `diagnostic_msgs` dependencies.
- Added `Hardware Status` diagnostics:
  - I2C initialization state
  - gyro and accelerometer range information
  - chip temperature
  - `PWR_MGMT_2` axis standby state
  - explicit I2C register read failure reporting
- Added `Data Status` diagnostics:
  - configured publish rate
  - published sample count
  - latest sample freshness
  - latest sample range validation
  - explicit sample read failure reporting
- Added checked I2C byte and word read helpers.
- Skips IMU and roll/pitch publish for cycles where sample register reads fail.
- Documented `/diagnostics` in the README.
- Added MockI2C-based gtests for diagnostics behavior.

## Verification

- `git diff --check` passed.
- GitHub Actions CI passed.
- Local `colcon test` was not run because ROS 2 / `colcon` is not installed in the local environment.

## Risk

- Normal IMU and `roll_pitch` publish paths are preserved for successful reads.
- Real hardware verification for temperature and `PWR_MGMT_2` reads is still recommended.

Refs #22
