### PR TITLE
refactor: type MPU6050 register constants

### DIFF
--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -24,17 +24,18 @@
 #include <string>
 #include <utility>
 
-#define ACCEL_X_OUT 0x3b
-#define ACCEL_Y_OUT 0x3d
-#define ACCEL_Z_OUT 0x3f
-#define TEMP_OUT    0x41  // Built-in temperature sensor (for diagnostics: thermal monitoring)
-#define GYRO_X_OUT  0x43
-#define GYRO_Y_OUT  0x45
-#define GYRO_Z_OUT  0x47
+static constexpr unsigned int ACCEL_X_OUT = 0x3b;
+static constexpr unsigned int ACCEL_Y_OUT = 0x3d;
+static constexpr unsigned int ACCEL_Z_OUT = 0x3f;
+static constexpr unsigned int TEMP_OUT = 0x41;  // Built-in temperature sensor for diagnostics.
+static constexpr unsigned int GYRO_X_OUT = 0x43;
+static constexpr unsigned int GYRO_Y_OUT = 0x45;
+static constexpr unsigned int GYRO_Z_OUT = 0x47;
 
-#define PWR_MGMT_1 0x6B
-#define PWR_MGMT_2 0x6C  // Axis standby flags: bits[5:3]=gyro XYZ, bits[2:0]=accel XYZ (for diagnostics)
-#define DEV_ADDR   0x68
+static constexpr int PWR_MGMT_1 = 0x6B;
+// Axis standby flags: bits[5:3]=gyro XYZ, bits[2:0]=accel XYZ.
+static constexpr unsigned int PWR_MGMT_2 = 0x6C;
+static constexpr int DEV_ADDR = 0x68;
 
 // MPU6050 sensitivity: ±250°/s range → 131 LSB/(°/s)
 static constexpr float GYRO_SENSITIVITY_LSB = 131.0f;

--- a/test/test_mpu6050_driver.cpp
+++ b/test/test_mpu6050_driver.cpp
@@ -269,6 +269,20 @@ TEST(Mpu6050DriverTest, PublishesHardwareDiagnosticErrorWhenRegisterReadFails)
   EXPECT_EQ(status.message, "I2C read failed");
 }
 
+TEST(Mpu6050DriverTest, PublishesHardwareDiagnosticErrorWhenRegisterReadOutOfRange)
+{
+  MockI2C mock;
+  mock.reg_values[0x41] = 0x100;  // TEMP_OUT high byte must be an unsigned byte.
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  ASSERT_TRUE(spinAndCaptureDiagnosticStatus(node, "Hardware Status", &status))
+    << "Expected a hardware diagnostic status";
+  EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_EQ(status.message, "I2C read failed");
+}
+
 TEST(Mpu6050DriverTest, PublishesDataDiagnosticOkAfterSample)
 {
   MockI2C mock;
@@ -289,6 +303,20 @@ TEST(Mpu6050DriverTest, PublishesDataDiagnosticErrorWhenSampleReadFails)
 {
   MockI2C mock;
   mock.reg_values[0x43] = -1;  // GYRO_X high byte read failure
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  ASSERT_TRUE(spinAndCaptureDiagnosticStatus(node, "Data Status", &status))
+    << "Expected a data diagnostic status";
+  EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_EQ(status.message, "I2C read failed");
+}
+
+TEST(Mpu6050DriverTest, PublishesDataDiagnosticErrorWhenRegisterReadOutOfRange)
+{
+  MockI2C mock;
+  mock.reg_values[0x43] = 0x100;  // GYRO_X high byte must be an unsigned byte.
   rclcpp::NodeOptions opts;
   auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
 


### PR DESCRIPTION
## Summary

Refactors MPU6050 register definitions from preprocessor macros to typed `static constexpr` constants.

This keeps register values unchanged while improving type clarity and limiting macro scope. It also adds regression coverage for I2C byte reads that return values outside the valid unsigned byte range.

## Changes

- Replaced MPU6050 register `#define` constants in `src/mpu6050_driver_node.cpp` with `static constexpr` constants.
- Moved the `PWR_MGMT_2` axis standby explanation next to the typed constant.
- Added diagnostics regression tests for `readReg8()` returning `0x100`:
  - `Hardware Status` reports `ERROR: I2C read failed`.
  - `Data Status` reports `ERROR: I2C read failed`.

## Verification

- `git diff --check` passed.
- GitHub Actions CI passed.
- Local `colcon test` was not run because ROS 2 / `colcon` is not installed in the local environment.

## Risk

- Runtime register values and I2C behavior are unchanged.
- The added tests only lock in existing invalid-read diagnostics behavior.
