### PR TITLE
fix: publish IMU output in SI units

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,22 @@ ros2 launch imu_driver mpu6050_driver.launch.xml publish_rate_hz:=200.0
 
 | Topic | Type | Description |
 |-------|------|-------------|
-| `output` | `sensor_msgs/Imu` | Raw IMU data (angular velocity + linear acceleration) |
+| `output` | `sensor_msgs/Imu` | IMU data using ROS SI units (`rad/s` angular velocity, `m/s^2` linear acceleration) |
 | `roll_pitch` | `geometry_msgs/Vector3Stamped` | Roll and pitch angles in degrees (`x=roll`, `y=pitch`, `z=0`) |
 | `/diagnostics` | `diagnostic_msgs/DiagnosticArray` | Driver health status for ROS diagnostics tools |
+
+### IMU Units
+
+The `output` topic follows the standard `sensor_msgs/Imu` unit conventions:
+
+| Field | Unit |
+|-------|------|
+| `angular_velocity` | `rad/s` |
+| `linear_acceleration` | `m/s^2` |
+
+Internally, the MPU6050 is configured for ±250 deg/s gyro range and ±2g accelerometer range. The driver converts those raw sensor units before publishing `sensor_msgs/Imu`.
+
+If you used an earlier version of this driver that published deg/s and g on `output`, remove downstream unit adapters or disable their `gyro_in_degrees` / `accel_in_g` style conversions to avoid double conversion.
 
 ### Diagnostics
 

--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -41,14 +41,16 @@ static constexpr int DEV_ADDR = 0x68;
 static constexpr float GYRO_SENSITIVITY_LSB = 131.0f;
 // MPU6050 sensitivity: ±2g range → 16384 LSB/g
 static constexpr float ACCEL_SENSITIVITY_LSB = 16384.0f;
-// Radians to degrees conversion factor
+// Unit conversion factors
 static constexpr float RAD_TO_DEG = 180.0f / M_PI;
+static constexpr float DEG_TO_RAD = M_PI / 180.0f;
+static constexpr float STANDARD_GRAVITY = 9.80665f;
 static constexpr double DEFAULT_PUBLISH_RATE_HZ = 100.0;
 static constexpr int64_t MIN_TIMER_PERIOD_MS = 1;
 static constexpr float TEMP_WARN_C = 70.0f;
 static constexpr float TEMP_ERROR_C = 85.0f;
-static constexpr float MAX_ACCEL_G = 2.5f;
-static constexpr float MAX_GYRO_DPS = 260.0f;
+static constexpr float MAX_ACCEL_MPS2 = 2.5f * STANDARD_GRAVITY;
+static constexpr float MAX_GYRO_RADPS = 260.0f * DEG_TO_RAD;
 static constexpr double STALE_SAMPLE_PERIOD_MULTIPLIER = 3.0;
 
 Mpu6050Driver::Mpu6050Driver(
@@ -137,9 +139,9 @@ bool Mpu6050Driver::updateCurrentGyroData()
     return false;
   }
   gyro_ = {{
-    gyro_x / GYRO_SENSITIVITY_LSB,
-    gyro_y / GYRO_SENSITIVITY_LSB,
-    gyro_z / GYRO_SENSITIVITY_LSB,
+    gyro_x / GYRO_SENSITIVITY_LSB * DEG_TO_RAD,
+    gyro_y / GYRO_SENSITIVITY_LSB * DEG_TO_RAD,
+    gyro_z / GYRO_SENSITIVITY_LSB * DEG_TO_RAD,
   }};
   return true;
 }
@@ -157,9 +159,9 @@ bool Mpu6050Driver::updateCurrentAccelData()
     return false;
   }
   accel_ = {{
-    accel_x / ACCEL_SENSITIVITY_LSB,
-    accel_y / ACCEL_SENSITIVITY_LSB,
-    accel_z / ACCEL_SENSITIVITY_LSB,
+    accel_x / ACCEL_SENSITIVITY_LSB * STANDARD_GRAVITY,
+    accel_y / ACCEL_SENSITIVITY_LSB * STANDARD_GRAVITY,
+    accel_z / ACCEL_SENSITIVITY_LSB * STANDARD_GRAVITY,
   }};
   return true;
 }
@@ -228,6 +230,8 @@ void Mpu6050Driver::checkHardwareStatus(diagnostic_updater::DiagnosticStatusWrap
   stat.add("I2C connection", fd_ == -1 ? "not initialized" : "ok");
   stat.add("Gyro sensitivity", "131 LSB/(deg/s) [+-250 deg/s]");
   stat.add("Accel sensitivity", "16384 LSB/g [+-2g]");
+  stat.add("IMU output angular velocity unit", "rad/s");
+  stat.add("IMU output linear acceleration unit", "m/s^2");
 
   if (fd_ == -1) {
     stat.summary(DiagnosticStatus::ERROR, "I2C not initialized");
@@ -296,12 +300,12 @@ void Mpu6050Driver::checkDataStatus(diagnostic_updater::DiagnosticStatusWrapper 
 bool Mpu6050Driver::isLatestSampleValid() const
 {
   for (const auto value : accel_) {
-    if (!std::isfinite(value) || std::fabs(value) > MAX_ACCEL_G) {
+    if (!std::isfinite(value) || std::fabs(value) > MAX_ACCEL_MPS2) {
       return false;
     }
   }
   for (const auto value : gyro_) {
-    if (!std::isfinite(value) || std::fabs(value) > MAX_GYRO_DPS) {
+    if (!std::isfinite(value) || std::fabs(value) > MAX_GYRO_RADPS) {
       return false;
     }
   }

--- a/test/test_mpu6050_driver.cpp
+++ b/test/test_mpu6050_driver.cpp
@@ -29,6 +29,9 @@
 #include <string>
 #include <thread>
 
+static constexpr float DEG_TO_RAD = M_PI / 180.0f;
+static constexpr float STANDARD_GRAVITY = 9.80665f;
+
 // ---------------------------------------------------------------------------
 // Mock I2C implementation for testing without real hardware
 // ---------------------------------------------------------------------------
@@ -361,7 +364,7 @@ TEST(Mpu6050DriverTest, AcceptsPositivePublishRateOverride)
 
 TEST(Mpu6050DriverTest, PositiveAccelValueConvertedCorrectly)
 {
-  // Raw = 0x1000 = 4096 => accel_x = 4096 / 16384.0 = 0.25 g
+  // Raw = 0x1000 = 4096 => accel_x = 4096 / 16384.0 = 0.25 g = 2.4516625 m/s^2
   MockI2C mock;
   mock.reg_values[0x3b] = 0x10;  // ACCEL_X high byte
   mock.reg_values[0x3c] = 0x00;  // ACCEL_X low byte
@@ -370,13 +373,13 @@ TEST(Mpu6050DriverTest, PositiveAccelValueConvertedCorrectly)
 
   auto msg = spinAndCapture(node);
   ASSERT_NE(msg, nullptr) << "Expected an IMU message to be published";
-  EXPECT_FLOAT_EQ(msg->linear_acceleration.x, 0.25f);
+  EXPECT_FLOAT_EQ(msg->linear_acceleration.x, 0.25f * STANDARD_GRAVITY);
 }
 
 TEST(Mpu6050DriverTest, NegativeAccelValueConvertedCorrectly)
 {
   // Raw = 0x8000 = 32768 => two's complement: 32768 - 65536 = -32768
-  // => accel_x = -32768 / 16384.0 = -2.0 g
+  // => accel_x = -32768 / 16384.0 = -2.0 g = -19.6133 m/s^2
   // Regression: old code used value-65534, yielding -1.9999... instead of -2.0
   MockI2C mock;
   mock.reg_values[0x3b] = 0x80;  // ACCEL_X high byte
@@ -386,12 +389,12 @@ TEST(Mpu6050DriverTest, NegativeAccelValueConvertedCorrectly)
 
   auto msg = spinAndCapture(node);
   ASSERT_NE(msg, nullptr);
-  EXPECT_FLOAT_EQ(msg->linear_acceleration.x, -2.0f);
+  EXPECT_FLOAT_EQ(msg->linear_acceleration.x, -2.0f * STANDARD_GRAVITY);
 }
 
 TEST(Mpu6050DriverTest, MaxNegativeAccelValue)
 {
-  // Raw = 0xFFFF = 65535 => two's complement: -1 => -1 / 16384.0
+  // Raw = 0xFFFF = 65535 => two's complement: -1 => -1 / 16384.0 g
   MockI2C mock;
   mock.reg_values[0x3b] = 0xFF;
   mock.reg_values[0x3c] = 0xFF;
@@ -400,12 +403,12 @@ TEST(Mpu6050DriverTest, MaxNegativeAccelValue)
 
   auto msg = spinAndCapture(node);
   ASSERT_NE(msg, nullptr);
-  EXPECT_NEAR(msg->linear_acceleration.x, -1.0f / 16384.0f, 1e-6f);
+  EXPECT_NEAR(msg->linear_acceleration.x, -STANDARD_GRAVITY / 16384.0f, 1e-6f);
 }
 
 TEST(Mpu6050DriverTest, MaxPositiveAccelValue)
 {
-  // Raw = 0x7FFF = 32767 => 32767 / 16384.0
+  // Raw = 0x7FFF = 32767 => 32767 / 16384.0 g
   MockI2C mock;
   mock.reg_values[0x3b] = 0x7F;
   mock.reg_values[0x3c] = 0xFF;
@@ -414,12 +417,12 @@ TEST(Mpu6050DriverTest, MaxPositiveAccelValue)
 
   auto msg = spinAndCapture(node);
   ASSERT_NE(msg, nullptr);
-  EXPECT_NEAR(msg->linear_acceleration.x, 32767.0f / 16384.0f, 1e-4f);
+  EXPECT_NEAR(msg->linear_acceleration.x, 32767.0f / 16384.0f * STANDARD_GRAVITY, 1e-4f);
 }
 
 TEST(Mpu6050DriverTest, GyroScalingApplied)
 {
-  // Raw = 0x0083 = 131 => angular_velocity.x = 131 / 131.0 = 1.0
+  // Raw = 0x0083 = 131 => angular_velocity.x = 131 / 131.0 = 1.0 deg/s
   MockI2C mock;
   mock.reg_values[0x43] = 0x00;
   mock.reg_values[0x44] = 0x83;
@@ -428,13 +431,13 @@ TEST(Mpu6050DriverTest, GyroScalingApplied)
 
   auto msg = spinAndCapture(node);
   ASSERT_NE(msg, nullptr);
-  EXPECT_NEAR(msg->angular_velocity.x, 1.0f, 1e-4f);
+  EXPECT_NEAR(msg->angular_velocity.x, 1.0f * DEG_TO_RAD, 1e-4f);
 }
 
 TEST(Mpu6050DriverTest, NegativeGyroScalingApplied)
 {
   // Raw = 0xFF7D = 65405 => two's complement: 65405 - 65536 = -131
-  // => angular_velocity.x = -131 / 131.0 = -1.0
+  // => angular_velocity.x = -131 / 131.0 = -1.0 deg/s
   MockI2C mock;
   mock.reg_values[0x43] = 0xFF;
   mock.reg_values[0x44] = 0x7D;
@@ -443,7 +446,7 @@ TEST(Mpu6050DriverTest, NegativeGyroScalingApplied)
 
   auto msg = spinAndCapture(node);
   ASSERT_NE(msg, nullptr);
-  EXPECT_NEAR(msg->angular_velocity.x, -1.0f, 1e-4f);
+  EXPECT_NEAR(msg->angular_velocity.x, -1.0f * DEG_TO_RAD, 1e-4f);
 }
 
 TEST(Mpu6050DriverTest, ImuMessageHasCorrectFrameId)
@@ -474,17 +477,17 @@ TEST(Mpu6050DriverTest, AllAxesPublishedCorrectly)
 {
   // Set distinct values on all 6 axes to verify they are mapped correctly.
   MockI2C mock;
-  // Accel X: raw = 0x0200 = 512  => 512  / 16384.0 = 0.03125
+  // Accel X: raw = 0x0200 = 512  => 512  / 16384.0 = 0.03125 g
   mock.reg_values[0x3b] = 0x02; mock.reg_values[0x3c] = 0x00;
-  // Accel Y: raw = 0x0400 = 1024 => 1024 / 16384.0 = 0.0625
+  // Accel Y: raw = 0x0400 = 1024 => 1024 / 16384.0 = 0.0625 g
   mock.reg_values[0x3d] = 0x04; mock.reg_values[0x3e] = 0x00;
-  // Accel Z: raw = 0x0800 = 2048 => 2048 / 16384.0 = 0.125
+  // Accel Z: raw = 0x0800 = 2048 => 2048 / 16384.0 = 0.125 g
   mock.reg_values[0x3f] = 0x08; mock.reg_values[0x40] = 0x00;
-  // Gyro X: raw = 0x0083 = 131   => 131  / 131.0   = 1.0
+  // Gyro X: raw = 0x0083 = 131   => 131  / 131.0   = 1.0 deg/s
   mock.reg_values[0x43] = 0x00; mock.reg_values[0x44] = 0x83;
-  // Gyro Y: raw = 0x0106 = 262   => 262  / 131.0   = 2.0
+  // Gyro Y: raw = 0x0106 = 262   => 262  / 131.0   = 2.0 deg/s
   mock.reg_values[0x45] = 0x01; mock.reg_values[0x46] = 0x06;
-  // Gyro Z: raw = 0x0189 = 393   => 393  / 131.0   = 3.0
+  // Gyro Z: raw = 0x0189 = 393   => 393  / 131.0   = 3.0 deg/s
   mock.reg_values[0x47] = 0x01; mock.reg_values[0x48] = 0x89;
 
   rclcpp::NodeOptions opts;
@@ -492,12 +495,12 @@ TEST(Mpu6050DriverTest, AllAxesPublishedCorrectly)
 
   auto msg = spinAndCapture(node);
   ASSERT_NE(msg, nullptr);
-  EXPECT_NEAR(msg->linear_acceleration.x, 0.03125f, 1e-4f);
-  EXPECT_NEAR(msg->linear_acceleration.y, 0.0625f,  1e-4f);
-  EXPECT_NEAR(msg->linear_acceleration.z, 0.125f,   1e-4f);
-  EXPECT_NEAR(msg->angular_velocity.x,    1.0f,     1e-4f);
-  EXPECT_NEAR(msg->angular_velocity.y,    2.0f,     1e-4f);
-  EXPECT_NEAR(msg->angular_velocity.z,    3.0f,     1e-4f);
+  EXPECT_NEAR(msg->linear_acceleration.x, 0.03125f * STANDARD_GRAVITY, 1e-4f);
+  EXPECT_NEAR(msg->linear_acceleration.y, 0.0625f * STANDARD_GRAVITY,  1e-4f);
+  EXPECT_NEAR(msg->linear_acceleration.z, 0.125f * STANDARD_GRAVITY,   1e-4f);
+  EXPECT_NEAR(msg->angular_velocity.x,    1.0f * DEG_TO_RAD,           1e-4f);
+  EXPECT_NEAR(msg->angular_velocity.y,    2.0f * DEG_TO_RAD,           1e-4f);
+  EXPECT_NEAR(msg->angular_velocity.z,    3.0f * DEG_TO_RAD,           1e-4f);
 }
 
 TEST(Mpu6050DriverTest, RollPitchZeroWhenFlat)


### PR DESCRIPTION
## Summary

Fixes `sensor_msgs/Imu` output units so the `output` topic follows ROS SI conventions.

## Changes

- Convert MPU6050 gyro readings from deg/s to rad/s before publishing `angular_velocity`.
- Convert accelerometer readings from g to m/s^2 before publishing `linear_acceleration`.
- Update data diagnostics range checks to use SI thresholds.
- Add diagnostic values documenting the published IMU units.
- Update gtests to lock the SI output values.
- Document the unit behavior and migration note in the README.
- Update Issue #30 title/body to English Conventional Commits style metadata.

## Verification

- `git diff --check`
- Local `colcon test` was not run because ROS 2 / `colcon` is not installed in this environment.
- GitHub Actions CI should run on this PR.

## Risk

- This intentionally changes the published `output` topic values from deg/s and g to rad/s and m/s^2.
- Existing downstream adapters that already convert deg/s or g must be removed or disabled to avoid double conversion.

Closes #30
