### PR TITLE
feat: configure IMU covariance parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ Internally, the MPU6050 is configured for ±250 deg/s gyro range and ±2g accele
 
 If you used an earlier version of this driver that published deg/s and g on `output`, remove downstream unit adapters or disable their `gyro_in_degrees` / `accel_in_g` style conversions to avoid double conversion.
 
+### IMU Covariance
+
+The driver does not estimate orientation on the `output` topic, so `orientation_covariance[0]` is set to `-1` in every `sensor_msgs/Imu` message.
+
+Angular velocity and linear acceleration covariance arrays are configurable as row-major 3x3 matrices. They default to all zeros for compatibility; set them when feeding the driver output into an EKF or another estimator that requires explicit sensor uncertainty.
+
+Example parameter override:
+
+```sh
+ros2 run imu_driver imu_driver --ros-args \
+  -p angular_velocity_covariance:="[0.0004, 0.0, 0.0, 0.0, 0.0004, 0.0, 0.0, 0.0, 0.0004]" \
+  -p linear_acceleration_covariance:="[0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]"
+```
+
 ### Diagnostics
 
 The driver publishes two diagnostic statuses:
@@ -138,6 +152,8 @@ ros2 topic echo /diagnostics
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `publish_rate_hz` | double | `100.0` | IMU publish rate in Hz |
+| `angular_velocity_covariance` | double[9] | all zeros | Row-major 3x3 covariance for `angular_velocity` in `(rad/s)^2` |
+| `linear_acceleration_covariance` | double[9] | all zeros | Row-major 3x3 covariance for `linear_acceleration` in `(m/s^2)^2` |
 
 ### Sensor Configuration
 

--- a/include/imu_driver/mpu6050_driver.hpp
+++ b/include/imu_driver/mpu6050_driver.hpp
@@ -47,6 +47,7 @@ private:
   void checkHardwareStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void checkDataStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
   bool isLatestSampleValid() const;
+  std::array<double, 9> getCovarianceParameter(const std::string & parameter_name);
   bool readReg8Checked(int fd, unsigned int reg, int * value);
   bool read2data(int fd, unsigned int reg, float * value);
 
@@ -56,6 +57,8 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
   std::array<float, 3> gyro_{};
   std::array<float, 3> accel_{};
+  std::array<double, 9> angular_velocity_covariance_{};
+  std::array<double, 9> linear_acceleration_covariance_{};
   rclcpp::Time last_sample_time_;
   double publish_rate_hz_ = 0.0;
   std::size_t sample_count_ = 0;

--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -18,11 +18,13 @@
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <rclcpp/timer.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 static constexpr unsigned int ACCEL_X_OUT = 0x3b;
 static constexpr unsigned int ACCEL_Y_OUT = 0x3d;
@@ -52,6 +54,12 @@ static constexpr float TEMP_ERROR_C = 85.0f;
 static constexpr float MAX_ACCEL_MPS2 = 2.5f * STANDARD_GRAVITY;
 static constexpr float MAX_GYRO_RADPS = 260.0f * DEG_TO_RAD;
 static constexpr double STALE_SAMPLE_PERIOD_MULTIPLIER = 3.0;
+static constexpr std::size_t COVARIANCE_SIZE = 9;
+
+static std::vector<double> defaultCovarianceParameter()
+{
+  return std::vector<double>(COVARIANCE_SIZE, 0.0);
+}
 
 Mpu6050Driver::Mpu6050Driver(
   const std::string & node_name,
@@ -68,6 +76,10 @@ Mpu6050Driver::Mpu6050Driver(
   }
 
   declare_parameter<double>("publish_rate_hz", DEFAULT_PUBLISH_RATE_HZ);
+  declare_parameter<std::vector<double>>(
+    "angular_velocity_covariance", defaultCovarianceParameter());
+  declare_parameter<std::vector<double>>(
+    "linear_acceleration_covariance", defaultCovarianceParameter());
   double rate_hz = get_parameter("publish_rate_hz").as_double();
   if (!std::isfinite(rate_hz) || rate_hz <= 0.0) {
     RCLCPP_ERROR(
@@ -83,6 +95,8 @@ Mpu6050Driver::Mpu6050Driver(
     period_ms = MIN_TIMER_PERIOD_MS;
   }
   publish_rate_hz_ = rate_hz;
+  angular_velocity_covariance_ = getCovarianceParameter("angular_velocity_covariance");
+  linear_acceleration_covariance_ = getCovarianceParameter("linear_acceleration_covariance");
 
   imu_pub_ = create_publisher<sensor_msgs::msg::Imu>("output", rclcpp::QoS{10});
   roll_pitch_pub_ =
@@ -200,12 +214,15 @@ void Mpu6050Driver::imuDataPublish()
 
   msg.header.stamp = last_sample_time_;
   msg.header.frame_id = "imu";
+  msg.orientation_covariance[0] = -1.0;
   msg.angular_velocity.x = gyro_[0];
   msg.angular_velocity.y = gyro_[1];
   msg.angular_velocity.z = gyro_[2];
+  msg.angular_velocity_covariance = angular_velocity_covariance_;
   msg.linear_acceleration.x = accel_[0];
   msg.linear_acceleration.y = accel_[1];
   msg.linear_acceleration.z = accel_[2];
+  msg.linear_acceleration_covariance = linear_acceleration_covariance_;
   imu_pub_->publish(msg);
 }
 
@@ -310,4 +327,18 @@ bool Mpu6050Driver::isLatestSampleValid() const
     }
   }
   return true;
+}
+
+std::array<double, 9> Mpu6050Driver::getCovarianceParameter(const std::string & parameter_name)
+{
+  std::array<double, 9> covariance{};
+  const auto values = get_parameter(parameter_name).as_double_array();
+  if (values.size() != covariance.size()) {
+    RCLCPP_ERROR(
+      get_logger(), "Parameter '%s' must contain exactly %zu values; using all zeros",
+      parameter_name.c_str(), covariance.size());
+    return covariance;
+  }
+  std::copy(values.begin(), values.end(), covariance.begin());
+  return covariance;
 }

--- a/test/test_mpu6050_driver.cpp
+++ b/test/test_mpu6050_driver.cpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <string>
 #include <thread>
+#include <vector>
 
 static constexpr float DEG_TO_RAD = M_PI / 180.0f;
 static constexpr float STANDARD_GRAVITY = 9.80665f;
@@ -471,6 +472,66 @@ TEST(Mpu6050DriverTest, ImuMessageTimestampIsSet)
   const auto & stamp = msg->header.stamp;
   EXPECT_TRUE(stamp.sec != 0 || stamp.nanosec != 0)
     << "Message timestamp must be filled in";
+}
+
+TEST(Mpu6050DriverTest, ImuCovarianceDefaultsArePublished)
+{
+  MockI2C mock;
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+  EXPECT_EQ(msg->orientation_covariance[0], -1.0);
+  for (std::size_t i = 1; i < msg->orientation_covariance.size(); ++i) {
+    EXPECT_EQ(msg->orientation_covariance[i], 0.0);
+  }
+  for (const auto value : msg->angular_velocity_covariance) {
+    EXPECT_EQ(value, 0.0);
+  }
+  for (const auto value : msg->linear_acceleration_covariance) {
+    EXPECT_EQ(value, 0.0);
+  }
+}
+
+TEST(Mpu6050DriverTest, ImuCovarianceOverridesArePublished)
+{
+  const std::vector<double> angular_covariance{
+    0.001, 0.002, 0.003,
+    0.004, 0.005, 0.006,
+    0.007, 0.008, 0.009};
+  const std::vector<double> linear_covariance{
+    0.101, 0.102, 0.103,
+    0.104, 0.105, 0.106,
+    0.107, 0.108, 0.109};
+  MockI2C mock;
+  rclcpp::NodeOptions opts;
+  opts.parameter_overrides({
+    rclcpp::Parameter("angular_velocity_covariance", angular_covariance),
+    rclcpp::Parameter("linear_acceleration_covariance", linear_covariance)});
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+  for (std::size_t i = 0; i < angular_covariance.size(); ++i) {
+    EXPECT_EQ(msg->angular_velocity_covariance[i], angular_covariance[i]);
+    EXPECT_EQ(msg->linear_acceleration_covariance[i], linear_covariance[i]);
+  }
+}
+
+TEST(Mpu6050DriverTest, InvalidCovarianceOverrideFallsBackToZero)
+{
+  MockI2C mock;
+  rclcpp::NodeOptions opts;
+  opts.parameter_overrides({
+    rclcpp::Parameter("angular_velocity_covariance", std::vector<double>{0.001, 0.002})});
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+  for (const auto value : msg->angular_velocity_covariance) {
+    EXPECT_EQ(value, 0.0);
+  }
 }
 
 TEST(Mpu6050DriverTest, AllAxesPublishedCorrectly)


### PR DESCRIPTION
## 概要

Issue #32 の対応として、`sensor_msgs/Imu` の covariance を明示・設定できるようにしました。

## 変更内容

- `orientation_covariance[0] = -1` を常に設定し、この driver が `output` topic では orientation を推定しないことを明示
- `angular_velocity_covariance` / `linear_acceleration_covariance` パラメータを追加
  - 9 要素の row-major 3x3 配列
  - 既定値は互換性重視で all zero
  - 要素数が 9 でない場合は ERROR ログを出して all zero にフォールバック
- covariance の既定値、上書き、無効な上書きの gtest を追加
- README に covariance の意味、単位、EKF 向け設定例を追加

## 確認

- `git diff --check`

## 未確認

- この環境には ROS 2 / `colcon` がないため、ローカル `colcon test` は未実行です。GitHub Actions CI で `test_mpu6050_driver` を確認してください。

## リスク

- 既存 topic 名、frame ID、publish rate、SI 単位変換は変更していません。
- `orientation_covariance[0] = -1` は `sensor_msgs/Imu` の慣例に沿った明示化ですが、orientation covariance が all zero である前提の downstream がある場合は表示上の差分になります。

Closes #32

🤖 Generated with Codex automation