### PR TITLE
feat: configure IMU covariance parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,15 @@ The `output` topic follows the standard `sensor_msgs/Imu` unit conventions:
 | Field | Unit |
 |-------|------|
 | `angular_velocity` | `rad/s` |
+| `angular_velocity_covariance` | `(rad/s)^2` |
 | `linear_acceleration` | `m/s^2` |
+| `linear_acceleration_covariance` | `(m/s^2)^2` |
 
 Internally, the MPU6050 is configured for ±250 deg/s gyro range and ±2g accelerometer range. The driver converts those raw sensor units before publishing `sensor_msgs/Imu`.
 
 If you used an earlier version of this driver that published deg/s and g on `output`, remove downstream unit adapters or disable their `gyro_in_degrees` / `accel_in_g` style conversions to avoid double conversion.
+
+The driver does not estimate orientation on the `output` topic, so `orientation_covariance[0]` is always set to `-1.0`.
 
 ### Diagnostics
 
@@ -138,6 +142,21 @@ ros2 topic echo /diagnostics
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `publish_rate_hz` | double | `100.0` | IMU publish rate in Hz |
+| `angular_velocity_covariance` | double[9] | `[0.0, ...]` | Row-major covariance for `angular_velocity`; all-zero means unknown |
+| `linear_acceleration_covariance` | double[9] | `[0.0, ...]` | Row-major covariance for `linear_acceleration`; all-zero means unknown |
+
+Covariance parameters map directly to the 3x3 row-major arrays in `sensor_msgs/Imu`.
+For a diagonal-only configuration, keep off-diagonal terms at `0.0`:
+
+```sh
+ros2 launch imu_driver mpu6050_driver.launch.xml \
+  angular_velocity_covariance:="[0.0004, 0.0, 0.0, 0.0, 0.0004, 0.0, 0.0, 0.0, 0.0004]" \
+  linear_acceleration_covariance:="[0.04, 0.0, 0.0, 0.0, 0.04, 0.0, 0.0, 0.0, 0.04]"
+```
+
+For EKF or filter integration, replace these examples with values derived from measurement,
+datasheet assumptions, or a calibration procedure. The all-zero defaults preserve ROS's
+unknown-covariance semantics and are not tuned estimator values.
 
 ### Sensor Configuration
 

--- a/include/imu_driver/mpu6050_driver.hpp
+++ b/include/imu_driver/mpu6050_driver.hpp
@@ -26,6 +26,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 
 class Mpu6050Driver : public rclcpp::Node
 {
@@ -49,6 +50,9 @@ private:
   bool isLatestSampleValid() const;
   bool readReg8Checked(int fd, unsigned int reg, int * value);
   bool read2data(int fd, unsigned int reg, float * value);
+  std::array<double, 9> parseCovarianceParameter(
+    const std::string & parameter_name,
+    const std::vector<double> & values) const;
 
   diagnostic_updater::Updater diagnostic_updater_;
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
@@ -56,6 +60,8 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
   std::array<float, 3> gyro_{};
   std::array<float, 3> accel_{};
+  std::array<double, 9> angular_velocity_covariance_{};
+  std::array<double, 9> linear_acceleration_covariance_{};
   rclcpp::Time last_sample_time_;
   double publish_rate_hz_ = 0.0;
   std::size_t sample_count_ = 0;

--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -18,11 +18,13 @@
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <rclcpp/timer.hpp>
 
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 static constexpr unsigned int ACCEL_X_OUT = 0x3b;
 static constexpr unsigned int ACCEL_Y_OUT = 0x3d;
@@ -52,6 +54,12 @@ static constexpr float TEMP_ERROR_C = 85.0f;
 static constexpr float MAX_ACCEL_MPS2 = 2.5f * STANDARD_GRAVITY;
 static constexpr float MAX_GYRO_RADPS = 260.0f * DEG_TO_RAD;
 static constexpr double STALE_SAMPLE_PERIOD_MULTIPLIER = 3.0;
+static constexpr std::array<double, 9> ORIENTATION_NOT_ESTIMATED_COVARIANCE{
+  -1.0, 0.0, 0.0,
+  0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0,
+};
+static const std::vector<double> DEFAULT_MEASUREMENT_COVARIANCE(9, 0.0);
 
 Mpu6050Driver::Mpu6050Driver(
   const std::string & node_name,
@@ -68,6 +76,16 @@ Mpu6050Driver::Mpu6050Driver(
   }
 
   declare_parameter<double>("publish_rate_hz", DEFAULT_PUBLISH_RATE_HZ);
+  const auto angular_velocity_covariance = declare_parameter<std::vector<double>>(
+    "angular_velocity_covariance", DEFAULT_MEASUREMENT_COVARIANCE);
+  const auto linear_acceleration_covariance = declare_parameter<std::vector<double>>(
+    "linear_acceleration_covariance", DEFAULT_MEASUREMENT_COVARIANCE);
+
+  angular_velocity_covariance_ = parseCovarianceParameter(
+    "angular_velocity_covariance", angular_velocity_covariance);
+  linear_acceleration_covariance_ = parseCovarianceParameter(
+    "linear_acceleration_covariance", linear_acceleration_covariance);
+
   double rate_hz = get_parameter("publish_rate_hz").as_double();
   if (!std::isfinite(rate_hz) || rate_hz <= 0.0) {
     RCLCPP_ERROR(
@@ -200,12 +218,15 @@ void Mpu6050Driver::imuDataPublish()
 
   msg.header.stamp = last_sample_time_;
   msg.header.frame_id = "imu";
+  msg.orientation_covariance = ORIENTATION_NOT_ESTIMATED_COVARIANCE;
   msg.angular_velocity.x = gyro_[0];
   msg.angular_velocity.y = gyro_[1];
   msg.angular_velocity.z = gyro_[2];
+  msg.angular_velocity_covariance = angular_velocity_covariance_;
   msg.linear_acceleration.x = accel_[0];
   msg.linear_acceleration.y = accel_[1];
   msg.linear_acceleration.z = accel_[2];
+  msg.linear_acceleration_covariance = linear_acceleration_covariance_;
   imu_pub_->publish(msg);
 }
 
@@ -310,4 +331,42 @@ bool Mpu6050Driver::isLatestSampleValid() const
     }
   }
   return true;
+}
+
+std::array<double, 9> Mpu6050Driver::parseCovarianceParameter(
+  const std::string & parameter_name,
+  const std::vector<double> & values) const
+{
+  std::array<double, 9> covariance{};
+  if (values.size() != covariance.size()) {
+    RCLCPP_ERROR(
+      get_logger(), "Invalid %s size %zu; expected 9 values. Falling back to unknown covariance.",
+      parameter_name.c_str(), values.size());
+    return {};
+  }
+
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    if (!std::isfinite(values[i])) {
+      RCLCPP_ERROR(
+        get_logger(),
+        "Invalid %s value at index %zu; covariance values must be finite. "
+        "Falling back to unknown covariance.",
+        parameter_name.c_str(), i);
+      return {};
+    }
+    covariance[i] = values[i];
+  }
+
+  for (const auto diagonal_index : {0u, 4u, 8u}) {
+    if (covariance[diagonal_index] < 0.0) {
+      RCLCPP_ERROR(
+        get_logger(),
+        "Invalid %s diagonal value at index %u; diagonal values must be non-negative. "
+        "Falling back to unknown covariance.",
+        parameter_name.c_str(), diagonal_index);
+      return {};
+    }
+  }
+
+  return covariance;
 }

--- a/test/test_mpu6050_driver.cpp
+++ b/test/test_mpu6050_driver.cpp
@@ -23,11 +23,14 @@
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
+#include <array>
 #include <chrono>
 #include <cmath>
+#include <limits>
 #include <map>
 #include <string>
 #include <thread>
+#include <vector>
 
 static constexpr float DEG_TO_RAD = M_PI / 180.0f;
 static constexpr float STANDARD_GRAVITY = 9.80665f;
@@ -145,6 +148,28 @@ static rclcpp::NodeOptions optionsWithPublishRate(double rate_hz)
   rclcpp::NodeOptions opts;
   opts.parameter_overrides({rclcpp::Parameter("publish_rate_hz", rate_hz)});
   return opts;
+}
+
+static rclcpp::NodeOptions optionsWithCovariances(
+  const std::vector<double> & angular_velocity_covariance,
+  const std::vector<double> & linear_acceleration_covariance)
+{
+  rclcpp::NodeOptions opts;
+  opts.parameter_overrides({
+    rclcpp::Parameter("angular_velocity_covariance", angular_velocity_covariance),
+    rclcpp::Parameter("linear_acceleration_covariance", linear_acceleration_covariance),
+  });
+  return opts;
+}
+
+template<typename Covariance>
+static void expectCovarianceEquals(
+  const Covariance & actual,
+  const std::array<double, 9> & expected)
+{
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_DOUBLE_EQ(actual[i], expected[i]) << "Covariance index " << i << " differs";
+  }
 }
 
 TEST(Mpu6050DriverTest, WakesDeviceFromSleepOnInit)
@@ -471,6 +496,149 @@ TEST(Mpu6050DriverTest, ImuMessageTimestampIsSet)
   const auto & stamp = msg->header.stamp;
   EXPECT_TRUE(stamp.sec != 0 || stamp.nanosec != 0)
     << "Message timestamp must be filled in";
+}
+
+TEST(Mpu6050DriverTest, ImuMessageUsesDefaultCovariances)
+{
+  MockI2C mock;
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+
+  std::array<double, 9> default_orientation_covariance{};
+  default_orientation_covariance[0] = -1.0;
+  const std::array<double, 9> default_measurement_covariance{};
+
+  expectCovarianceEquals(msg->orientation_covariance, default_orientation_covariance);
+  expectCovarianceEquals(msg->angular_velocity_covariance, default_measurement_covariance);
+  expectCovarianceEquals(msg->linear_acceleration_covariance, default_measurement_covariance);
+}
+
+TEST(Mpu6050DriverTest, ImuMessagePublishesConfiguredCovariances)
+{
+  MockI2C mock;
+  const std::vector<double> angular_velocity_covariance{
+    0.01, 0.001, 0.002,
+    0.001, 0.02, 0.003,
+    0.002, 0.003, 0.03,
+  };
+  const std::vector<double> linear_acceleration_covariance{
+    0.10, 0.011, 0.012,
+    0.011, 0.20, 0.013,
+    0.012, 0.013, 0.30,
+  };
+  auto opts = optionsWithCovariances(angular_velocity_covariance, linear_acceleration_covariance);
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+
+  const std::array<double, 9> expected_angular_velocity_covariance{
+    0.01, 0.001, 0.002,
+    0.001, 0.02, 0.003,
+    0.002, 0.003, 0.03,
+  };
+  const std::array<double, 9> expected_linear_acceleration_covariance{
+    0.10, 0.011, 0.012,
+    0.011, 0.20, 0.013,
+    0.012, 0.013, 0.30,
+  };
+
+  expectCovarianceEquals(msg->angular_velocity_covariance, expected_angular_velocity_covariance);
+  expectCovarianceEquals(
+    msg->linear_acceleration_covariance, expected_linear_acceleration_covariance);
+}
+
+TEST(Mpu6050DriverTest, ImuMessageFallsBackWhenCovarianceSizeIsInvalid)
+{
+  MockI2C mock;
+  const std::vector<double> invalid_angular_velocity_covariance{0.01, 0.02, 0.03};
+  const std::vector<double> linear_acceleration_covariance{
+    0.10, 0.0, 0.0,
+    0.0, 0.20, 0.0,
+    0.0, 0.0, 0.30,
+  };
+  auto opts =
+    optionsWithCovariances(invalid_angular_velocity_covariance, linear_acceleration_covariance);
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+
+  const std::array<double, 9> default_measurement_covariance{};
+  const std::array<double, 9> expected_linear_acceleration_covariance{
+    0.10, 0.0, 0.0,
+    0.0, 0.20, 0.0,
+    0.0, 0.0, 0.30,
+  };
+
+  expectCovarianceEquals(msg->angular_velocity_covariance, default_measurement_covariance);
+  expectCovarianceEquals(
+    msg->linear_acceleration_covariance, expected_linear_acceleration_covariance);
+}
+
+TEST(Mpu6050DriverTest, ImuMessageFallsBackWhenCovarianceContainsNonFiniteValue)
+{
+  MockI2C mock;
+  const std::vector<double> angular_velocity_covariance{
+    0.01, 0.0, 0.0,
+    0.0, std::numeric_limits<double>::quiet_NaN(), 0.0,
+    0.0, 0.0, 0.03,
+  };
+  const std::vector<double> linear_acceleration_covariance{
+    0.10, 0.0, 0.0,
+    0.0, 0.20, 0.0,
+    0.0, 0.0, 0.30,
+  };
+  auto opts = optionsWithCovariances(angular_velocity_covariance, linear_acceleration_covariance);
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+
+  const std::array<double, 9> default_measurement_covariance{};
+  const std::array<double, 9> expected_linear_acceleration_covariance{
+    0.10, 0.0, 0.0,
+    0.0, 0.20, 0.0,
+    0.0, 0.0, 0.30,
+  };
+
+  expectCovarianceEquals(msg->angular_velocity_covariance, default_measurement_covariance);
+  expectCovarianceEquals(
+    msg->linear_acceleration_covariance, expected_linear_acceleration_covariance);
+}
+
+TEST(Mpu6050DriverTest, ImuMessageFallsBackWhenCovarianceDiagonalIsNegative)
+{
+  MockI2C mock;
+  const std::vector<double> angular_velocity_covariance{
+    0.01, 0.0, 0.0,
+    0.0, 0.02, 0.0,
+    0.0, 0.0, 0.03,
+  };
+  const std::vector<double> invalid_linear_acceleration_covariance{
+    0.10, 0.0, 0.0,
+    0.0, -0.20, 0.0,
+    0.0, 0.0, 0.30,
+  };
+  auto opts =
+    optionsWithCovariances(angular_velocity_covariance, invalid_linear_acceleration_covariance);
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+
+  const std::array<double, 9> expected_angular_velocity_covariance{
+    0.01, 0.0, 0.0,
+    0.0, 0.02, 0.0,
+    0.0, 0.0, 0.03,
+  };
+  const std::array<double, 9> default_measurement_covariance{};
+
+  expectCovarianceEquals(msg->angular_velocity_covariance, expected_angular_velocity_covariance);
+  expectCovarianceEquals(msg->linear_acceleration_covariance, default_measurement_covariance);
 }
 
 TEST(Mpu6050DriverTest, AllAxesPublishedCorrectly)


### PR DESCRIPTION
## Summary

- Add configurable angular velocity and linear acceleration covariance parameters.
- Publish `orientation_covariance[0] = -1.0` because the driver does not estimate orientation on the `output` topic.
- Validate covariance parameter shape, finite values, and non-negative diagonal values with fallback to unknown covariance.
- Document covariance units, all-zero unknown semantics, and a diagonal-only launch example.

Closes #32.

## Impact

- Existing topic names, frame ID, publish rate behavior, SI units, diagnostics, and roll/pitch behavior are unchanged.
- Default angular velocity and linear acceleration covariance values remain all zero, preserving ROS unknown-covariance semantics.
- Invalid covariance parameter values no longer propagate to published messages; they fall back to all-zero unknown covariance.

## Tests

- Added publish-and-capture tests for default covariance behavior.
- Added parameter override tests for angular velocity and linear acceleration covariance.
- Added invalid parameter fallback tests for wrong size, non-finite values, and negative diagonal values.
- Ran `git diff --check`.
- Local `colcon` is unavailable in this environment; GitHub Actions must validate build and test execution.

## Rollback

- Revert this commit to remove the new parameters, covariance publishing, tests, and README updates.
