### PR TITLE
feat: add static IMU bias calibration offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,28 @@ ros2 topic echo /diagnostics
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `publish_rate_hz` | double | `100.0` | IMU publish rate in Hz |
+| `angular_velocity_bias` | double[3] | `[0.0, 0.0, 0.0]` | Static gyro bias to subtract from `angular_velocity` in `rad/s` |
+| `linear_acceleration_bias` | double[3] | `[0.0, 0.0, 0.0]` | Static accelerometer bias to subtract from `linear_acceleration` in `m/s^2` |
 | `angular_velocity_covariance` | double[9] | `[0.0, ...]` | Row-major covariance for `angular_velocity`; all-zero means unknown |
 | `linear_acceleration_covariance` | double[9] | `[0.0, ...]` | Row-major covariance for `linear_acceleration`; all-zero means unknown |
+
+Bias offsets are applied after raw sensor scaling and SI unit conversion:
+
+```text
+published_value = scaled_sensor_value - configured_bias
+```
+
+The corrected acceleration sample is also used by the `roll_pitch` topic.
+
+For an initial stationary bias estimate:
+
+1. Place the IMU in its normal mounted orientation and keep it still.
+2. Record a short sample window from the `output` topic after startup.
+3. Use the mean angular velocity on each axis as `angular_velocity_bias`.
+4. For linear acceleration, subtract the expected gravity vector for the mounted orientation from the measured mean, then use the residual as `linear_acceleration_bias`.
+5. Keep all values in ROS SI units (`rad/s` and `m/s^2`).
+
+This is a static correction only. Re-estimate the offsets when the sensor, mounting, or operating environment changes.
 
 Covariance parameters map directly to the 3x3 row-major arrays in `sensor_msgs/Imu`.
 For a diagonal-only configuration, keep off-diagonal terms at `0.0`:

--- a/include/imu_driver/mpu6050_driver.hpp
+++ b/include/imu_driver/mpu6050_driver.hpp
@@ -50,6 +50,9 @@ private:
   bool isLatestSampleValid() const;
   bool readReg8Checked(int fd, unsigned int reg, int * value);
   bool read2data(int fd, unsigned int reg, float * value);
+  std::array<double, 3> parseBiasParameter(
+    const std::string & parameter_name,
+    const std::vector<double> & values) const;
   std::array<double, 9> parseCovarianceParameter(
     const std::string & parameter_name,
     const std::vector<double> & values) const;
@@ -58,8 +61,10 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
   rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr roll_pitch_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
-  std::array<float, 3> gyro_{};
-  std::array<float, 3> accel_{};
+  std::array<double, 3> gyro_{};
+  std::array<double, 3> accel_{};
+  std::array<double, 3> angular_velocity_bias_{};
+  std::array<double, 3> linear_acceleration_bias_{};
   std::array<double, 9> angular_velocity_covariance_{};
   std::array<double, 9> linear_acceleration_covariance_{};
   rclcpp::Time last_sample_time_;

--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -59,6 +59,7 @@ static constexpr std::array<double, 9> ORIENTATION_NOT_ESTIMATED_COVARIANCE{
   0.0, 0.0, 0.0,
   0.0, 0.0, 0.0,
 };
+static const std::vector<double> DEFAULT_BIAS(3, 0.0);
 static const std::vector<double> DEFAULT_MEASUREMENT_COVARIANCE(9, 0.0);
 
 Mpu6050Driver::Mpu6050Driver(
@@ -76,11 +77,18 @@ Mpu6050Driver::Mpu6050Driver(
   }
 
   declare_parameter<double>("publish_rate_hz", DEFAULT_PUBLISH_RATE_HZ);
+  const auto angular_velocity_bias = declare_parameter<std::vector<double>>(
+    "angular_velocity_bias", DEFAULT_BIAS);
+  const auto linear_acceleration_bias = declare_parameter<std::vector<double>>(
+    "linear_acceleration_bias", DEFAULT_BIAS);
   const auto angular_velocity_covariance = declare_parameter<std::vector<double>>(
     "angular_velocity_covariance", DEFAULT_MEASUREMENT_COVARIANCE);
   const auto linear_acceleration_covariance = declare_parameter<std::vector<double>>(
     "linear_acceleration_covariance", DEFAULT_MEASUREMENT_COVARIANCE);
 
+  angular_velocity_bias_ = parseBiasParameter("angular_velocity_bias", angular_velocity_bias);
+  linear_acceleration_bias_ = parseBiasParameter(
+    "linear_acceleration_bias", linear_acceleration_bias);
   angular_velocity_covariance_ = parseCovarianceParameter(
     "angular_velocity_covariance", angular_velocity_covariance);
   linear_acceleration_covariance_ = parseCovarianceParameter(
@@ -157,9 +165,9 @@ bool Mpu6050Driver::updateCurrentGyroData()
     return false;
   }
   gyro_ = {{
-    gyro_x / GYRO_SENSITIVITY_LSB * DEG_TO_RAD,
-    gyro_y / GYRO_SENSITIVITY_LSB * DEG_TO_RAD,
-    gyro_z / GYRO_SENSITIVITY_LSB * DEG_TO_RAD,
+    gyro_x / GYRO_SENSITIVITY_LSB * DEG_TO_RAD - angular_velocity_bias_[0],
+    gyro_y / GYRO_SENSITIVITY_LSB * DEG_TO_RAD - angular_velocity_bias_[1],
+    gyro_z / GYRO_SENSITIVITY_LSB * DEG_TO_RAD - angular_velocity_bias_[2],
   }};
   return true;
 }
@@ -177,9 +185,9 @@ bool Mpu6050Driver::updateCurrentAccelData()
     return false;
   }
   accel_ = {{
-    accel_x / ACCEL_SENSITIVITY_LSB * STANDARD_GRAVITY,
-    accel_y / ACCEL_SENSITIVITY_LSB * STANDARD_GRAVITY,
-    accel_z / ACCEL_SENSITIVITY_LSB * STANDARD_GRAVITY,
+    accel_x / ACCEL_SENSITIVITY_LSB * STANDARD_GRAVITY - linear_acceleration_bias_[0],
+    accel_y / ACCEL_SENSITIVITY_LSB * STANDARD_GRAVITY - linear_acceleration_bias_[1],
+    accel_z / ACCEL_SENSITIVITY_LSB * STANDARD_GRAVITY - linear_acceleration_bias_[2],
   }};
   return true;
 }
@@ -331,6 +339,33 @@ bool Mpu6050Driver::isLatestSampleValid() const
     }
   }
   return true;
+}
+
+std::array<double, 3> Mpu6050Driver::parseBiasParameter(
+  const std::string & parameter_name,
+  const std::vector<double> & values) const
+{
+  std::array<double, 3> bias{};
+  if (values.size() != bias.size()) {
+    RCLCPP_ERROR(
+      get_logger(), "Invalid %s size %zu; expected 3 values. Falling back to zero bias.",
+      parameter_name.c_str(), values.size());
+    return {};
+  }
+
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    if (!std::isfinite(values[i])) {
+      RCLCPP_ERROR(
+        get_logger(),
+        "Invalid %s value at index %zu; bias values must be finite. "
+        "Falling back to zero bias.",
+        parameter_name.c_str(), i);
+      return {};
+    }
+    bias[i] = values[i];
+  }
+
+  return bias;
 }
 
 std::array<double, 9> Mpu6050Driver::parseCovarianceParameter(

--- a/test/test_mpu6050_driver.cpp
+++ b/test/test_mpu6050_driver.cpp
@@ -162,6 +162,18 @@ static rclcpp::NodeOptions optionsWithCovariances(
   return opts;
 }
 
+static rclcpp::NodeOptions optionsWithBiases(
+  const std::vector<double> & angular_velocity_bias,
+  const std::vector<double> & linear_acceleration_bias)
+{
+  rclcpp::NodeOptions opts;
+  opts.parameter_overrides({
+    rclcpp::Parameter("angular_velocity_bias", angular_velocity_bias),
+    rclcpp::Parameter("linear_acceleration_bias", linear_acceleration_bias),
+  });
+  return opts;
+}
+
 template<typename Covariance>
 static void expectCovarianceEquals(
   const Covariance & actual,
@@ -472,6 +484,104 @@ TEST(Mpu6050DriverTest, NegativeGyroScalingApplied)
   auto msg = spinAndCapture(node);
   ASSERT_NE(msg, nullptr);
   EXPECT_NEAR(msg->angular_velocity.x, -1.0f * DEG_TO_RAD, 1e-4f);
+}
+
+TEST(Mpu6050DriverTest, DefaultBiasOffsetsPreservePublishedImuValues)
+{
+  MockI2C mock;
+  // Accel X/Y/Z: 0.25g, 0.5g, 1.0g.
+  mock.reg_values[0x3b] = 0x10; mock.reg_values[0x3c] = 0x00;
+  mock.reg_values[0x3d] = 0x20; mock.reg_values[0x3e] = 0x00;
+  mock.reg_values[0x3f] = 0x40; mock.reg_values[0x40] = 0x00;
+  // Gyro X/Y/Z: 1, 2, 3 deg/s.
+  mock.reg_values[0x43] = 0x00; mock.reg_values[0x44] = 0x83;
+  mock.reg_values[0x45] = 0x01; mock.reg_values[0x46] = 0x06;
+  mock.reg_values[0x47] = 0x01; mock.reg_values[0x48] = 0x89;
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+  EXPECT_NEAR(msg->linear_acceleration.x, 0.25f * STANDARD_GRAVITY, 1e-4f);
+  EXPECT_NEAR(msg->linear_acceleration.y, 0.5f * STANDARD_GRAVITY, 1e-4f);
+  EXPECT_NEAR(msg->linear_acceleration.z, 1.0f * STANDARD_GRAVITY, 1e-4f);
+  EXPECT_NEAR(msg->angular_velocity.x, 1.0f * DEG_TO_RAD, 1e-4f);
+  EXPECT_NEAR(msg->angular_velocity.y, 2.0f * DEG_TO_RAD, 1e-4f);
+  EXPECT_NEAR(msg->angular_velocity.z, 3.0f * DEG_TO_RAD, 1e-4f);
+}
+
+TEST(Mpu6050DriverTest, AngularVelocityBiasOffsetsAreSubtracted)
+{
+  MockI2C mock;
+  // Gyro X/Y/Z: 1, 2, -1 deg/s.
+  mock.reg_values[0x43] = 0x00; mock.reg_values[0x44] = 0x83;
+  mock.reg_values[0x45] = 0x01; mock.reg_values[0x46] = 0x06;
+  mock.reg_values[0x47] = 0xFF; mock.reg_values[0x48] = 0x7D;
+  auto opts = optionsWithBiases(
+    {0.001, -0.002, 0.003},
+    {0.0, 0.0, 0.0});
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+  EXPECT_NEAR(msg->angular_velocity.x, 1.0 * DEG_TO_RAD - 0.001, 1e-6);
+  EXPECT_NEAR(msg->angular_velocity.y, 2.0 * DEG_TO_RAD + 0.002, 1e-6);
+  EXPECT_NEAR(msg->angular_velocity.z, -1.0 * DEG_TO_RAD - 0.003, 1e-6);
+}
+
+TEST(Mpu6050DriverTest, LinearAccelerationBiasOffsetsAreSubtracted)
+{
+  MockI2C mock;
+  // Accel X/Y/Z: 0.25g, -0.25g, 1.0g.
+  mock.reg_values[0x3b] = 0x10; mock.reg_values[0x3c] = 0x00;
+  mock.reg_values[0x3d] = 0xF0; mock.reg_values[0x3e] = 0x00;
+  mock.reg_values[0x3f] = 0x40; mock.reg_values[0x40] = 0x00;
+  auto opts = optionsWithBiases(
+    {0.0, 0.0, 0.0},
+    {0.10, -0.20, 0.30});
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+  EXPECT_NEAR(msg->linear_acceleration.x, 0.25 * STANDARD_GRAVITY - 0.10, 1e-5);
+  EXPECT_NEAR(msg->linear_acceleration.y, -0.25 * STANDARD_GRAVITY + 0.20, 1e-5);
+  EXPECT_NEAR(msg->linear_acceleration.z, 1.0 * STANDARD_GRAVITY - 0.30, 1e-5);
+}
+
+TEST(Mpu6050DriverTest, BiasOffsetsFallBackWhenSizeIsInvalid)
+{
+  MockI2C mock;
+  // Gyro X: 1 deg/s.
+  mock.reg_values[0x43] = 0x00; mock.reg_values[0x44] = 0x83;
+  // Accel X: 0.25g.
+  mock.reg_values[0x3b] = 0x10; mock.reg_values[0x3c] = 0x00;
+  auto opts = optionsWithBiases(
+    {0.010},
+    {0.10, 0.0, 0.0});
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+  EXPECT_NEAR(msg->angular_velocity.x, 1.0 * DEG_TO_RAD, 1e-6);
+  EXPECT_NEAR(msg->linear_acceleration.x, 0.25 * STANDARD_GRAVITY - 0.10, 1e-5);
+}
+
+TEST(Mpu6050DriverTest, BiasOffsetsFallBackWhenValueIsNonFinite)
+{
+  MockI2C mock;
+  // Gyro X: 1 deg/s.
+  mock.reg_values[0x43] = 0x00; mock.reg_values[0x44] = 0x83;
+  // Accel X: 0.25g.
+  mock.reg_values[0x3b] = 0x10; mock.reg_values[0x3c] = 0x00;
+  auto opts = optionsWithBiases(
+    {0.010, 0.0, 0.0},
+    {std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0});
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  auto msg = spinAndCapture(node);
+  ASSERT_NE(msg, nullptr);
+  EXPECT_NEAR(msg->angular_velocity.x, 1.0 * DEG_TO_RAD - 0.010, 1e-6);
+  EXPECT_NEAR(msg->linear_acceleration.x, 0.25 * STANDARD_GRAVITY, 1e-5);
 }
 
 TEST(Mpu6050DriverTest, ImuMessageHasCorrectFrameId)


### PR DESCRIPTION
## Summary

- Add static gyro and accelerometer bias offset parameters.
- Subtract configured offsets after raw sensor scaling and ROS SI unit conversion.
- Validate bias parameter shape and finite values with fallback to zero bias.
- Document bias units, subtraction semantics, and a simple stationary estimate workflow.

Closes #33.

## Impact

- Default zero bias preserves existing IMU output behavior.
- Configured acceleration bias also affects the `roll_pitch` topic because it uses the corrected acceleration sample.
- Existing covariance parameters, topic names, frame ID, publish rate behavior, diagnostics, and SI units remain unchanged.

## Tests

- Added publish-and-capture tests for default zero bias behavior.
- Added gyro and accelerometer bias override tests.
- Added invalid bias fallback tests for wrong size and non-finite values.
- Ran `git diff --check`.
- Local `colcon` is unavailable in this environment; GitHub Actions must validate build and test execution.

## Rollback

- Revert this commit to remove the new bias parameters, subtraction behavior, tests, and README updates.
