### PR TITLE
feat: add IMU timestamp interval diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,26 @@ The driver publishes two diagnostic statuses:
 | Status | OK | WARN | ERROR |
 |--------|----|------|-------|
 | `Hardware Status` | I2C is initialized, temperature is normal, and all axes are active | Chip temperature is above 70°C or one or more axes are in standby | I2C is not initialized, an I2C register read fails, or chip temperature is above 85°C |
-| `Data Status` | IMU samples are recent and within the expected range | No sample has been published yet, the latest sample is stale, or the latest sample is outside the expected range | I2C is not initialized or the latest sample read failed |
+| `Data Status` | IMU samples are recent, within range, and on interval | No sample has been published yet, the latest sample is stale, outside the expected range, or has high interval jitter | I2C is not initialized or the latest sample read failed |
 
 You can inspect the diagnostics with:
 
 ```sh
 ros2 topic echo /diagnostics
 ```
+
+`Data Status` includes timing fields for runtime observation:
+
+| Field | Meaning |
+|-------|---------|
+| `Expected sample interval sec` | Effective timer interval after publish-rate clamping |
+| `Latest sample interval sec` | Time between the latest two published IMU samples |
+| `Latest sample interval error sec` | Absolute difference between latest and expected intervals |
+| `Max sample interval error sec` | Maximum observed interval error since node startup |
+| `Sample interval tolerance sec` | Warning threshold for interval error |
+
+For timing checks on hardware, run the node under expected robot load and watch
+`Latest sample interval error sec` and `Max sample interval error sec` in `/diagnostics`.
 
 ### Parameters
 

--- a/include/imu_driver/mpu6050_driver.hpp
+++ b/include/imu_driver/mpu6050_driver.hpp
@@ -69,9 +69,15 @@ private:
   std::array<double, 9> linear_acceleration_covariance_{};
   rclcpp::Time last_sample_time_;
   double publish_rate_hz_ = 0.0;
+  double expected_sample_interval_s_ = 0.0;
+  double sample_interval_tolerance_s_ = 0.0;
+  double latest_sample_interval_s_ = 0.0;
+  double latest_sample_interval_error_s_ = 0.0;
+  double max_sample_interval_error_s_ = 0.0;
   std::size_t sample_count_ = 0;
   bool latest_sample_read_ok_ = true;
   bool latest_sample_valid_ = false;
+  bool sample_interval_available_ = false;
 
   std::unique_ptr<II2CInterface> owned_i2c_;  ///< Owns the instance when created internally.
   II2CInterface * i2c_;                        ///< Non-owning pointer used for all I2C calls.

--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -109,6 +109,8 @@ Mpu6050Driver::Mpu6050Driver(
     period_ms = MIN_TIMER_PERIOD_MS;
   }
   publish_rate_hz_ = rate_hz;
+  expected_sample_interval_s_ = static_cast<double>(period_ms) / 1000.0;
+  sample_interval_tolerance_s_ = expected_sample_interval_s_;
 
   imu_pub_ = create_publisher<sensor_msgs::msg::Imu>("output", rclcpp::QoS{10});
   roll_pitch_pub_ =
@@ -220,7 +222,18 @@ bool Mpu6050Driver::read2data(int fd, unsigned int reg, float * value)
 void Mpu6050Driver::imuDataPublish()
 {
   sensor_msgs::msg::Imu msg;
-  last_sample_time_ = now();
+  const auto sample_time = now();
+  if (sample_count_ > 0) {
+    latest_sample_interval_s_ = (sample_time - last_sample_time_).seconds();
+    latest_sample_interval_error_s_ =
+      std::fabs(latest_sample_interval_s_ - expected_sample_interval_s_);
+    if (latest_sample_interval_error_s_ > max_sample_interval_error_s_) {
+      max_sample_interval_error_s_ = latest_sample_interval_error_s_;
+    }
+    sample_interval_available_ = true;
+  }
+
+  last_sample_time_ = sample_time;
   latest_sample_valid_ = isLatestSampleValid();
   ++sample_count_;
 
@@ -313,14 +326,25 @@ void Mpu6050Driver::checkDataStatus(diagnostic_updater::DiagnosticStatusWrapper 
   }
 
   const double sample_age_s = (now() - last_sample_time_).seconds();
-  const double expected_period_s = 1.0 / publish_rate_hz_;
   stat.add("Latest sample age sec", sample_age_s);
   stat.add("Latest sample valid", latest_sample_valid_);
+  stat.add("Expected sample interval sec", expected_sample_interval_s_);
+  stat.add("Sample interval tolerance sec", sample_interval_tolerance_s_);
+  if (sample_interval_available_) {
+    stat.add("Latest sample interval sec", latest_sample_interval_s_);
+    stat.add("Latest sample interval error sec", latest_sample_interval_error_s_);
+    stat.add("Max sample interval error sec", max_sample_interval_error_s_);
+  }
+  const bool interval_jitter_above_tolerance =
+    sample_interval_available_ &&
+    latest_sample_interval_error_s_ > sample_interval_tolerance_s_;
 
   if (!latest_sample_valid_) {
     stat.summary(DiagnosticStatus::WARN, "Latest IMU sample outside expected range");
-  } else if (sample_age_s > expected_period_s * STALE_SAMPLE_PERIOD_MULTIPLIER) {
+  } else if (sample_age_s > expected_sample_interval_s_ * STALE_SAMPLE_PERIOD_MULTIPLIER) {
     stat.summary(DiagnosticStatus::WARN, "No recent IMU sample");
+  } else if (interval_jitter_above_tolerance) {
+    stat.summary(DiagnosticStatus::WARN, "IMU sample interval jitter above tolerance");
   } else {
     stat.summary(DiagnosticStatus::OK, "Data OK");
   }

--- a/test/test_mpu6050_driver.cpp
+++ b/test/test_mpu6050_driver.cpp
@@ -19,6 +19,7 @@
 
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <diagnostic_msgs/msg/key_value.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
@@ -184,6 +185,30 @@ static void expectCovarianceEquals(
   }
 }
 
+static const diagnostic_msgs::msg::KeyValue * findDiagnosticValue(
+  const diagnostic_msgs::msg::DiagnosticStatus & status,
+  const std::string & key)
+{
+  for (const auto & value : status.values) {
+    if (value.key == key) {
+      return &value;
+    }
+  }
+  return nullptr;
+}
+
+static double diagnosticValueAsDouble(
+  const diagnostic_msgs::msg::DiagnosticStatus & status,
+  const std::string & key)
+{
+  const auto * value = findDiagnosticValue(status, key);
+  EXPECT_NE(value, nullptr) << "Expected diagnostic key: " << key;
+  if (value == nullptr) {
+    return 0.0;
+  }
+  return std::stod(value->value);
+}
+
 TEST(Mpu6050DriverTest, WakesDeviceFromSleepOnInit)
 {
   // PWR_MGMT_1 (0x6B) must be written with 0x00 to wake MPU6050 from sleep.
@@ -337,6 +362,43 @@ TEST(Mpu6050DriverTest, PublishesDataDiagnosticOkAfterSample)
     << "Expected a data diagnostic status";
   EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
   EXPECT_EQ(status.message, "Data OK");
+}
+
+TEST(Mpu6050DriverTest, PublishesDataDiagnosticTimingFieldsAfterSamples)
+{
+  MockI2C mock;
+  rclcpp::NodeOptions opts;
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  ASSERT_NE(spinAndCapture(node), nullptr);
+  ASSERT_NE(spinAndCapture(node), nullptr);
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  ASSERT_TRUE(spinAndCaptureDiagnosticStatus(node, "Data Status", &status))
+    << "Expected a data diagnostic status";
+
+  EXPECT_DOUBLE_EQ(diagnosticValueAsDouble(status, "Expected sample interval sec"), 0.01);
+  EXPECT_GT(diagnosticValueAsDouble(status, "Latest sample interval sec"), 0.0);
+  EXPECT_GE(diagnosticValueAsDouble(status, "Latest sample interval error sec"), 0.0);
+  EXPECT_GE(diagnosticValueAsDouble(status, "Max sample interval error sec"), 0.0);
+  EXPECT_DOUBLE_EQ(diagnosticValueAsDouble(status, "Sample interval tolerance sec"), 0.01);
+}
+
+TEST(Mpu6050DriverTest, DataDiagnosticUsesClampedTimerPeriodForExpectedInterval)
+{
+  MockI2C mock;
+  auto opts = optionsWithPublishRate(5000.0);
+  auto node = std::make_shared<Mpu6050Driver>(testNodeName(), opts, &mock);
+
+  ASSERT_NE(spinAndCapture(node), nullptr);
+  ASSERT_NE(spinAndCapture(node), nullptr);
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  ASSERT_TRUE(spinAndCaptureDiagnosticStatus(node, "Data Status", &status))
+    << "Expected a data diagnostic status";
+
+  EXPECT_DOUBLE_EQ(diagnosticValueAsDouble(status, "Expected sample interval sec"), 0.001);
+  EXPECT_DOUBLE_EQ(diagnosticValueAsDouble(status, "Sample interval tolerance sec"), 0.001);
 }
 
 TEST(Mpu6050DriverTest, PublishesDataDiagnosticErrorWhenSampleReadFails)


### PR DESCRIPTION
## Summary

- Add IMU sample interval and interval-error tracking.
- Expose expected interval, latest interval, latest error, max error, and tolerance in `Data Status` diagnostics.
- Use the effective timer period after publish-rate clamping for expected interval and stale-sample checks.
- Document timing diagnostic fields and runtime observation guidance.

Closes #34.

## Impact

- Existing topic names, frame IDs, message timestamps, publish-rate parameters, covariance, bias offsets, and unit conversions remain unchanged.
- `Data Status` may warn when the latest interval error is greater than the effective expected interval.
- The first sample does not report interval metrics because no previous sample exists yet.

## Tests

- Added diagnostics tests for timing field reporting after multiple samples.
- Added diagnostics test for expected interval reporting when publish rate is clamped to the 1 ms timer floor.
- Ran `git diff --check`.
- Local `colcon` is unavailable in this environment; GitHub Actions must validate build and test execution.

## Notes

- An out-of-tolerance wall-clock test was intentionally not added because forcing scheduler jitter in CI would be brittle. Runtime verification is documented through `/diagnostics`.

## Rollback

- Revert this commit to remove timing diagnostic state, diagnostic fields, tests, and README updates.
