### PR TITLE
[codex] docs: expose effective IMU publish rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ ros2 topic echo /diagnostics
 
 | Field | Meaning |
 |-------|---------|
+| `Configured publish_rate_hz` | Requested publish rate after invalid values fall back to the default |
+| `Effective publish_rate_hz` | Timer-backed publish rate after millisecond timer resolution clamping |
 | `Expected sample interval sec` | Effective timer interval after publish-rate clamping |
 | `Latest sample interval sec` | Time between the latest two published IMU samples |
 | `Latest sample interval error sec` | Absolute difference between latest and expected intervals |

--- a/include/imu_driver/mpu6050_driver.hpp
+++ b/include/imu_driver/mpu6050_driver.hpp
@@ -69,6 +69,7 @@ private:
   std::array<double, 9> linear_acceleration_covariance_{};
   rclcpp::Time last_sample_time_;
   double publish_rate_hz_ = 0.0;
+  double effective_publish_rate_hz_ = 0.0;
   double expected_sample_interval_s_ = 0.0;
   double sample_interval_tolerance_s_ = 0.0;
   double latest_sample_interval_s_ = 0.0;

--- a/src/mpu6050_driver_node.cpp
+++ b/src/mpu6050_driver_node.cpp
@@ -110,6 +110,7 @@ Mpu6050Driver::Mpu6050Driver(
   }
   publish_rate_hz_ = rate_hz;
   expected_sample_interval_s_ = static_cast<double>(period_ms) / 1000.0;
+  effective_publish_rate_hz_ = 1.0 / expected_sample_interval_s_;
   sample_interval_tolerance_s_ = expected_sample_interval_s_;
 
   imu_pub_ = create_publisher<sensor_msgs::msg::Imu>("output", rclcpp::QoS{10});
@@ -309,6 +310,7 @@ void Mpu6050Driver::checkDataStatus(diagnostic_updater::DiagnosticStatusWrapper 
   using diagnostic_msgs::msg::DiagnosticStatus;
 
   stat.add("Configured publish_rate_hz", publish_rate_hz_);
+  stat.add("Effective publish_rate_hz", effective_publish_rate_hz_);
   stat.add("Published samples", sample_count_);
 
   if (fd_ == -1) {

--- a/test/test_mpu6050_driver.cpp
+++ b/test/test_mpu6050_driver.cpp
@@ -378,6 +378,7 @@ TEST(Mpu6050DriverTest, PublishesDataDiagnosticTimingFieldsAfterSamples)
     << "Expected a data diagnostic status";
 
   EXPECT_DOUBLE_EQ(diagnosticValueAsDouble(status, "Expected sample interval sec"), 0.01);
+  EXPECT_DOUBLE_EQ(diagnosticValueAsDouble(status, "Effective publish_rate_hz"), 100.0);
   EXPECT_GT(diagnosticValueAsDouble(status, "Latest sample interval sec"), 0.0);
   EXPECT_GE(diagnosticValueAsDouble(status, "Latest sample interval error sec"), 0.0);
   EXPECT_GE(diagnosticValueAsDouble(status, "Max sample interval error sec"), 0.0);
@@ -398,6 +399,8 @@ TEST(Mpu6050DriverTest, DataDiagnosticUsesClampedTimerPeriodForExpectedInterval)
     << "Expected a data diagnostic status";
 
   EXPECT_DOUBLE_EQ(diagnosticValueAsDouble(status, "Expected sample interval sec"), 0.001);
+  EXPECT_DOUBLE_EQ(diagnosticValueAsDouble(status, "Configured publish_rate_hz"), 5000.0);
+  EXPECT_DOUBLE_EQ(diagnosticValueAsDouble(status, "Effective publish_rate_hz"), 1000.0);
   EXPECT_DOUBLE_EQ(diagnosticValueAsDouble(status, "Sample interval tolerance sec"), 0.001);
 }
 


### PR DESCRIPTION
## 目的

`publish_rate_hz` が 1000Hz を超えるなどタイマー分解能により丸められる場合に、指定値と実際のタイマー周期から見た実効 publish rate を `/diagnostics` で区別して確認できるようにします。

## 変更内容

- `Data Status` に `Effective publish_rate_hz` を追加
- 既存の `Configured publish_rate_hz` は指定値または不正値 fallback 後の値として維持
- 1000Hz 超の指定で 1ms タイマーに clamp された場合、実効値が 1000Hz と表示されることをテストで確認
- README の diagnostics timing fields に新しい診断項目を追記

## 確認方法

- `git diff --check`

## 未確認

- この Windows 環境では `colcon` が見つからないため、ROS 2 のビルド/テストは未実行です。CI で `test_mpu6050_driver` の確認をお願いします。

## リスク

- publish 周期や既存トピックの挙動は変更していません。
- 追加は診断値とドキュメント、既存テストの期待値のみです。

🤖 Generated with Codex automation